### PR TITLE
Permit building both normal and tech-report formats.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /cheri-architecture.log
 /cheri-architecture.out
 /cheri-architecture.pdf
+/cheri-architecture-tr.pdf
 /cheri-architecture.run.xml
 /cheri-architecture.toc
 /fig-*.fls

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 TARGET=cheri-architecture.pdf
+TARGET_TR=cheri-architecture-tr.pdf
 PREVEOUS=../branches/20150624-cheri-architecture-1-13
 
 SAIL_LATEX_MIPS_DIR=sail_latex_mips
@@ -39,10 +40,10 @@ all: ${TARGET}
 # Howver, texloganalyser is included by default in some TeX distributions so
 # prefer that one.
 # TODO: fix the broken sail hyperrefs so we don't have to filter the out.
-${TARGET}: ${SOURCES} ${FIGSOURCES}
-	latexmk $(LATEXMK_COMMON_FLAGS) cheri-architecture.tex $(PDFLATEX_FLAGS); ret=$$?; \
+${TARGET} ${TARGET_TR}: ${SOURCES} ${FIGSOURCES}
+	latexmk $(LATEXMK_COMMON_FLAGS) $(@:.pdf=.tex) $(PDFLATEX_FLAGS); ret=$$?; \
 	    if command -v texloganalyser >/dev/null 2>/dev/null; then \
-	        texloganalyser $(TEXLOGANALYSER_FLAGS) build/cheri-architecture.log; \
+	        texloganalyser $(TEXLOGANALYSER_FLAGS) build/$(@:.pdf=.log); \
 	    fi; exit $$ret
 
 $(TIKZFIGURES): %.pdf: %.tex Makefile

--- a/cheri-architecture-tr.tex
+++ b/cheri-architecture-tr.tex
@@ -1,0 +1,5 @@
+%%%% Enable University of Cambridge tech-report formatting
+%%%% Use \ifdefined\trformat in other files to check the mode
+\def\trformat{}
+
+\input{cheri-architecture}

--- a/cheri-architecture.tex
+++ b/cheri-architecture.tex
@@ -1,19 +1,17 @@
-%%%% University of Cambridge tech-report formatting; enable when producing
-%%%% tech-report versions of these documents; otherwise, disable.
-%\documentclass[12pt,twoside,openright,a4paper]{report}
-%\setlength{\oddsidemargin}{-0.4mm} % 25 mm left margin
-%\setlength{\evensidemargin}{\oddsidemargin}
-%\setlength{\textwidth}{160mm}      % 25 mm right margin
-%\setlength{\topmargin}{-5.4mm}     % 20 mm top margin
-%\setlength{\headheight}{5mm}
-%\setlength{\headsep}{5mm}
-%\setlength{\footskip}{10mm}
-%\setlength{\textheight}{237mm}     % 20 mm bottom margin
-%%%% .. or regular document
+\ifdefined\trformat
+\documentclass[12pt,twoside,openright,a4paper]{report}
+\setlength{\oddsidemargin}{-0.4mm} % 25 mm left margin
+\setlength{\evensidemargin}{\oddsidemargin}
+\setlength{\textwidth}{160mm}      % 25 mm right margin
+\setlength{\topmargin}{-5.4mm}     % 20 mm top margin
+\setlength{\headheight}{5mm}
+\setlength{\headsep}{5mm}
+\setlength{\footskip}{10mm}
+\setlength{\textheight}{237mm}     % 20 mm bottom margin
+\else
 \documentclass[12pt,letterpaper,twoside,openright,fleqn]{report}
 \usepackage{etex}
-%%%% End of tech-report vs. regular
-%%%%
+\fi
 
 \input{preamble}
 
@@ -56,6 +54,8 @@
 }
 
 %% CL tech-report format provides its own cover page
+\ifdefined\trformat
+\else
 \begin{minipage}[h]{\textwidth}
   %\vspace{-.2cm}
   \maketitle
@@ -90,13 +90,14 @@
 
 }
 \end{minipage}
-%%
+\fi
 
 \normalsize
 
 %% CL tech-report format requires page numbering to start at 3
-%\setcounter{page}{3}
-%%
+\ifdefined\trformat
+\setcounter{page}{3}
+\fi
 
 %% For revisions sent for editing, prefer double spacing.
 %\doublespacing


### PR DESCRIPTION
Add a cheri-architecture-tr.tex that defines an empty 'trformat'
command and then includes cheri-architecture.tex.  Modify
cheri-architecture.tex to use \ifdefined\trformat around blocks
specific to tech-report formatting.

With these changes, a tech-report formatted can always be built as
cheri-architecture-tr.pdf.  The default build only builds the normal
format.