### PR TITLE
Add apt-get update to CI build workflow

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install latex
-      run: sudo apt-get install -y --no-install-recommends make texlive-plain-generic texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-science texlive-fonts-recommended texlive-fonts-extra texlive-bibtex-extra texlive-extra-utils biber latexmk
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make texlive-plain-generic texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-science texlive-fonts-recommended texlive-fonts-extra texlive-bibtex-extra texlive-extra-utils biber latexmk
     - name: Build document
       run: make
     - name: Upload artifact


### PR DESCRIPTION
This should fix the current 404 we're seeing while trying to run CI.