### PR TITLE
Make the CHERI exception codes architecture-specific.

### DIFF
--- a/chap-architecture.tex
+++ b/chap-architecture.tex
@@ -2352,8 +2352,7 @@ For example:
 In general, CHERI attempts to provide useful cause information when exceptions
 fire, including to identify whether an exception was triggered by using an
 invalid capability, dereferencing a sealed capability, or an access request
-not being authorized by capability permissions or bounds (see
-Section~\ref{sec:capability_exception_causes} for details).
+not being authorized by capability permissions or bounds.
 
 \subsubsection{Exception Delivery}
 
@@ -2439,61 +2438,8 @@ exception return, such as restoring the full \PCC{}.
 In each of the target ISAs (RISC-V and x86-64), we introduce a new
 exception to report capability violations.
 Since this exception covers a variety of error cases, each CHERI ISA
-must provide a capability exception code in an architecture-specific
-manner which indicates the specific violation.
-While the capability exception code delivery is architecture-specific,
-the capability exception codes are shared across all architectures.
-The possible capability exception codes are shown in Table~\ref{table:capability-cause}.
-
-\begin{table}
-\begin{center}
-\begin{threeparttable}
-\begin{tabular}{ll}
-\toprule
-Value & Description \\
-\midrule
-0x00 & None \\
-0x01 & Length Violation \\
-0x02 & Tag Violation \\
-0x03 & Seal Violation \\
-0x04 & Type Violation \\
-0x05 & \emph{reserved} \\
-0x06 & \emph{reserved} \\
-0x07 & \emph{reserved} \\
-0x08 & Software-defined Permission Violation \\
-0x09 & \emph{reserved} \\
-0x0a & \emph{reserved} \\
-0x0b & Unaligned Base \tnote{1} \\
-0x0c & \emph{reserved} \\
-0x0d & \emph{reserved} \\
-0x0e & \emph{reserved} \\
-0x0f & \emph{reserved} \\
-0x10 & \cappermG Violation \\
-0x11 & \cappermX Violation \\
-0x12 & \cappermL Violation \\
-0x13 & \cappermS Violation \\
-0x14 & \cappermLC Violation \\
-0x15 & \cappermSC Violation \\
-0x16 & \cappermSLC Violation \\
-0x17 & \emph{reserved} \\
-0x18 & \cappermASR Violation \\
-0x19 & \cappermInvoke Violation \\
-0x1a & \emph{reserved} \\
-0x1b & \emph{reserved} \\
-0x1c & \cappermCid Violation \\
-0x1d & \emph{reserved} \\
-0x1e & \emph{reserved} \\
-0x1f & \emph{reserved} \\
-\bottomrule
-\end{tabular}
-\begin{tablenotes}
-\item [1] Only used on CHERI-RISC-V.
-\end{tablenotes}
-\end{threeparttable}
-\end{center}
-\caption{Capability Exception Codes}
-\label{table:capability-cause}
-\end{table}
+must provide an architecture-specific capability exception code
+which indicates the specific violation.
 
 \subsubsection{Capability Exception Priority}
 \label{sec:capability_exception_priority}
@@ -2523,38 +2469,6 @@ Each architecture defines its own exception priority, and
 architecture-specific instantiations of CHERI must define an
 architecture-specific prioritization for capability-related exceptions
 relative to other exception types.
-
-If an instruction could potentially throw more than one capability exception,
-the capability exception code is set to the highest priority exception (numerically lowest
-priority value) as shown in Table~\ref{table:exception-priority}.
-
-\begin{table}
-\begin{center}
-\begin{tabular}{ll}
-\toprule
-Priority & Description \\
-\midrule
-1  & \cappermASR Violation \\
-2  & Tag Violation \\
-3  & Seal Violation \\
-4  & Type Violation \\
-5  & \cappermInvoke Violation \\
-   & \cappermCid Violation \\
-6  & \cappermX Violation \\
-7  & \cappermL Violation \\
-   & \cappermS Violation \\
-8  & \cappermLC Violation \\
-   & \cappermSC Violation \\
-9 & \cappermSLC Violation \\
-10 & \cappermG Violation \\
-11 & Length Violation \\
-12 & Software-defined Permission Violation \\
-\bottomrule
-\end{tabular}
-\end{center}
-\caption{Exception Priority}
-\label{table:exception-priority}
-\end{table}
 
 \subsection{Virtual Memory}
 \label{sec:virtual_memory}

--- a/chap-cheri-riscv.tex
+++ b/chap-cheri-riscv.tex
@@ -216,7 +216,7 @@ The following changes are specific to CHERI-RISC-V:
   Additional capability-specific exception cause information, such
   as more specific cause information and the identity of the faulting
   register is reported in the existing \xtval{} CSRs (see
-  Section~\ref{subsubsec-cheri-tval}).
+  Section~\ref{subsection:riscv:cheri-exception-reporting}).
 \item New per-mode capability CSRs are added as \xccsr{} (see
   Section~\ref{subsubsec-ccsrs}).
 \item CHERI-related page permissions are added to RISC-V architectural
@@ -472,35 +472,6 @@ corresponding privilege mode's CSRs. Debate still open over whether these are en
 \caption{CSR Whitelist. The accesses shown are the only CSR accesses that are permitted when the installed PCC does not have \cappermASR{}.}
 \label{tab:risc-v-access-system-registers-whitelist}
 \end{table}
-
-\subsubsection{Capability Exception Reporting}
-\label{subsubsec-cheri-tval}
-
-CHERI-RISC-V extends the definition of the Trap Value CSRs, \xtval{}, to
-report capability exception details as described in
-Figure~\ref{fig-cheri-tval} (shown for XLEN=32):
-
-\begin{figure}[!h]
-\begin{center}
-\begin{bytefield}[bitwidth=\textwidth/34]{32}
-  \bitheader[endianness=big]{0,4,5,10,31} \\
-  \bitbox{21}{\textbf{WPRI}}
-  \bitbox{6}{\texttt{cap idx}}
-  \bitbox{5}{\texttt{cause}}
-\end{bytefield}
-\caption{\xtval{} register format for Capability Exception}
-\label{fig-cheri-tval}
-\end{center}
-\end{figure}
-
-\begin{description}
-\item [cause] The \texttt{cause} field reports the capability exception code as described in Section~\ref{sec:capability_exception_causes}.
-\item [cap idx] The \texttt{cap idx} field reports the index of the capability register that caused the last exception.  When
-the most significant bit is set, the 5 least significant bits are used to index
-the special purpose capability register file described in
-Table~\ref{tab:risc-v-special-capability-registers}, otherwise, they index the
-general-purpose capability register file.
-\end{description}
 
 \subsubsection{Capability Control and Status Registers (CCSRs)}
 \label{subsubsec-ccsrs}
@@ -922,7 +893,7 @@ supervisor mode, with exceptions allowing controlled transition between those mo
 CHERI-RISC-V introduces several new exception-related Special Capability Registers
 to supplement existing RISC-V exception CSRs with new capability-related functionality.
 In addition, when a capability exception is raised, \xtval{} will provide
-details about the exception as described in Section~\ref{subsubsec-cheri-tval}.
+details about the exception as described in Section~\ref{subsection:riscv:cheri-exception-reporting}.
 
 \subsubsection{Exceptions to Machine Mode}
 We define the following new special capability registers that can be read and
@@ -1007,6 +978,109 @@ instruction fetch will trigger a further exception.
 %tag by an instruction would allow compiler-inserted instrumentation to check
 %for tag loss at suitable moments (e.g., after potentially tag-stripping
 %operations such as pointer manipulation).
+
+\subsection{Capability Exception Reporting}
+\label{subsection:riscv:cheri-exception-reporting}
+
+CHERI-RISC-V extends the definition of the Trap Value CSRs, \xtval{}, to
+report capability exception details as described in
+Figure~\ref{fig-cheri-tval} (shown for XLEN=32):
+
+\begin{figure}[!h]
+\begin{center}
+\begin{bytefield}[bitwidth=\textwidth/34]{32}
+  \bitheader[endianness=big]{0,4,5,10,31} \\
+  \bitbox{21}{\textbf{WPRI}}
+  \bitbox{6}{\texttt{cap idx}}
+  \bitbox{5}{\texttt{cause}}
+\end{bytefield}
+\caption{\xtval{} register format for Capability Exception}
+\label{fig-cheri-tval}
+\end{center}
+\end{figure}
+
+\begin{description}
+\item [cause] The \texttt{cause} field reports the capability
+  exception code from Table~\ref{tab:risc-v-capability-cause}.
+\item [cap idx] The \texttt{cap idx} field reports the index of the capability register that caused the last exception.  When
+the most significant bit is set, the 5 least significant bits are used to index
+the special purpose capability register file described in
+Table~\ref{tab:risc-v-special-capability-registers}, otherwise, they index the
+general-purpose capability register file.
+\end{description}
+
+\begin{table}
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+Value & Description \\
+\midrule
+0x00 & None \\
+0x01 & Length Violation \\
+0x02 & Tag Violation \\
+0x03 & Seal Violation \\
+0x04 & Type Violation \\
+0x05-0x07 & \emph{reserved} \\
+0x08 & Software-defined Permission Violation \\
+0x09-0x0a & \emph{reserved} \\
+0x0b & Unaligned Base \\
+0x0c-0x0f & \emph{reserved} \\
+0x10 & \cappermG Violation \\
+0x11 & \cappermX Violation \\
+0x12 & \cappermL Violation \\
+0x13 & \cappermS Violation \\
+0x14 & \cappermLC Violation \\
+0x15 & \cappermSC Violation \\
+0x16 & \cappermSLC Violation \\
+0x17 & \emph{reserved} \\
+0x18 & \cappermASR Violation \\
+0x19 & \cappermInvoke Violation \\
+0x1a-0x1b & \emph{reserved} \\
+0x1c & \cappermCid Violation \\
+0x1d-0x1f & \emph{reserved} \\
+\bottomrule
+\end{tabular}
+\end{center}
+\caption{CHERI-RISC-V Capability Exception Codes}
+\label{tab:risc-v-capability-cause}
+\end{table}
+
+\jhbnote{The current exception code values are inherited from
+  CHERI-MIPS.  They should probably be renumbered at some point.}
+
+If an instruction could potentially throw more than one capability exception,
+the capability exception code is set to the highest priority exception (numerically lowest
+priority value) as shown in Table~\ref{table:risc-v-exception-priority}.
+
+\begin{table}
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+Priority & Description \\
+\midrule
+1  & \cappermASR Violation \\
+2  & Tag Violation \\
+3  & Seal Violation \\
+4  & Type Violation \\
+5  & \cappermInvoke Violation \\
+   & \cappermCid Violation \\
+6  & \cappermX Violation \\
+7  & \cappermL Violation \\
+   & \cappermS Violation \\
+8  & \cappermLC Violation \\
+   & \cappermSC Violation \\
+9 & \cappermSLC Violation \\
+10 & \cappermG Violation \\
+11 & Length Violation \\
+12 & Software-defined Permission Violation \\
+\bottomrule
+\end{tabular}
+\end{center}
+\caption{CHERI-RISC-V Capability Exception Priority}
+\label{table:risc-v-exception-priority}
+\end{table}
+
+\jhbnote{Missing the unaligned base cause in the priority table}
 
 \subsection{Virtual Memory and Page Tables}
 \label{subsection:riscv:pagetables}

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -1059,8 +1059,74 @@ For reporting capability violations, we propose reserving a new
 exception vector.  This new exception would report an error code
 pushed as part of the exception frame similar to GP\# and PF\# faults.
 This error code would contain the capability exception code as
-described in Section~\ref{sec:capability_exception_causes} to indicate
+described in Table~\ref{table:x86:capability-cause} to indicate
 the specific violation.
+
+\begin{table}
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+Value & Description \\
+\midrule
+0x00 & None \\
+0x01 & Length Violation \\
+0x02 & Tag Violation \\
+0x03 & Seal Violation \\
+0x04 & Type Violation \\
+0x05-0x07 & \emph{reserved} \\
+0x08 & Software-defined Permission Violation \\
+0x09-0x0f & \emph{reserved} \\
+0x10 & \cappermG Violation \\
+0x11 & \cappermX Violation \\
+0x12 & \cappermL Violation \\
+0x13 & \cappermS Violation \\
+0x14 & \cappermLC Violation \\
+0x15 & \cappermSC Violation \\
+0x16 & \cappermSLC Violation \\
+0x17 & \emph{reserved} \\
+0x18 & \cappermASR Violation \\
+0x19 & \cappermInvoke Violation \\
+0x1a-0x1b & \emph{reserved} \\
+0x1c & \cappermCid Violation \\
+0x1d-0x1f & \emph{reserved} \\
+\bottomrule
+\end{tabular}
+\end{center}
+\caption{CHERI-x86-64 Capability Exception Error Codes}
+\label{table:x86:capability-cause}
+\end{table}
+
+If an instruction could potentially throw more than one capability exception,
+the capability exception error code is set to the highest priority exception (numerically lowest
+priority value) as shown in Table~\ref{table:x86:exception-priority}.
+
+\begin{table}
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+Priority & Description \\
+\midrule
+1  & \cappermASR Violation \\
+2  & Tag Violation \\
+3  & Seal Violation \\
+4  & Type Violation \\
+5  & \cappermInvoke Violation \\
+   & \cappermCid Violation \\
+6  & \cappermX Violation \\
+7  & \cappermL Violation \\
+   & \cappermS Violation \\
+8  & \cappermLC Violation \\
+   & \cappermSC Violation \\
+9 & \cappermSLC Violation \\
+10 & \cappermG Violation \\
+11 & Length Violation \\
+12 & Software-defined Permission Violation \\
+\bottomrule
+\end{tabular}
+\end{center}
+\caption{CHERI-x86-64 Capability Exception Priority}
+\label{table:x86:exception-priority}
+\end{table}
 
 CHERI-RISC-V includes the name of the register which
 triggers a capability violation.  It is not feasible to provide a


### PR DESCRIPTION
Move the tables out of the architecture chapter and into each architecture spec.  Morello already uses a different scheme for reporting exceptions that doesn't follow this code.

For RISC-V I moved the description of xtval out into a new subsection next to exception handling rather than being buried in a section about new CSRs.

For both RISC-V and x86-64 I have kept the existing values, but have condensed the tables slightly since they otherwise float several pages away.