### PR TITLE
Add more prose on direct memory-offset MOVs.

### DIFF
--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -622,6 +622,17 @@ add %csp,$16
     \insnnoref{CMPXCHG} should default to integer operands in
     capability mode.
 
+  \item \insnnoref{XCHGC} will also be required to support atomic
+    operations on capabilities.
+
+    The opcodes \texttt{87} and \texttt{90 + rd} would be extended to
+    support capability operands via the capability operand prefix.
+    The specific opcode \texttt{90} would remain a single byte
+    \insnnoref{NOP} which would not alter the value of \CAX{}.
+
+    \insnnoref{XCHG} should default to integer operands in capability
+    mode.
+
   \item It may also be desirable to support \insnnoref{XADDC}.  For
     this instruction, only the integer portion of the second (source)
     operand would be added to the integer value of the first

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -1502,3 +1502,8 @@ them to support capability operands.  These instructions could instead
 be extended to support capabilities both as immediates for the memory
 offset and as operands.  In that case, the opcodes would be retained
 in capability mode rather than deprecated.
+
+\subsection{XCHG [ER]AX Opcodes}
+
+If the \insnnoref{XCHG} instructions \texttt{91} - \texttt{97} are not
+commonly used, they could be deprecated in capability mode.

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -274,6 +274,7 @@ longer be valid:
   \item \insnnoref{LSS}
   \item \insnnoref{LAR}
   \item \insnnoref{LSL}
+  \item Direct memory-offset \insnnoref{MOV}
 \end{itemize}
 
 \subsection{Using Capabilities with Memory Address Operands}
@@ -372,6 +373,19 @@ Memory operands can be encoded without a base register, either as an
 absolute address, or an absolute address added to a scaled index
 register.  These operands are always evaluated as offsets relative to
 \DDC{} including in capability mode.
+
+\subsubsection{Direct Memory-Offset MOVs}
+
+The direct memory-offset \insnnoref{MOV} instructions store the
+absolute address of a memory operand as an immediate operand.
+Extending these instructions to support capability immediates would
+require padding nops to align the capability immediate as well as text
+relocations (even for position-dependent code).  However, we do not
+anticipate wide use of these instructions so instead choose to
+deprecate them in capability mode and restrict them to using integer
+operands and integer addressing.  Attempting to use these instructions
+with capability-aware addressing would be reserved and raise a UD\#
+exception.
 
 \subsubsection{Addresses Relative to CFS and CGS}
 
@@ -488,9 +502,8 @@ capability operands:
     Note that these instructions would only permit a general-purpose
     register as the source (\texttt{89}) or destination (\texttt{8B}).
 
-    The \texttt{A1} and \texttt{A2} opcodes would be extended to use
-    \CAX{} as the implicit operand when used with the capability
-    operand prefix.
+    The \texttt{A1} and \texttt{A3} opcodes would not be extended to
+    support capabilities.
 
     To permit moving the contents of an additional capability register
     to a general-purpose register or vice versa, two
@@ -1465,3 +1478,13 @@ which are commonly used and default to 64-bit operands).  It may make
 sense to deprecate far branches other than \insnnoref{IRET} completely
 in capability mode causing the instructions to raise an illegal
 instruction fault.
+
+\subsection{Direct Memory-Offset MOVs}
+
+These four \insnnoref{MOV} instructions store the address of their
+memory operand inline as an immediate.  Currently, we propose
+deprecating these instructions in capability code and not extending
+them to support capability operands.  These instructions could instead
+be extended to support capabilities both as immediates for the memory
+offset and as operands.  In that case, the opcodes would be retained
+in capability mode rather than deprecated.

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -608,7 +608,7 @@ add %csp,$16
     be extended to support capability operands via the capability
     operand prefix.
 
-    \insnnoref{AND}, \insnnoref{ORC}, and \insnnoref{XOR} should
+    \insnnoref{AND}, \insnnoref{OR}, and \insnnoref{XOR} should
     default to integer operands in capability mode.
 
   \item \insnnoref{CMPXCHGC} will be required to support atomic

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -371,7 +371,9 @@ or store is constrained by the bounds and permissions of \CIP{}.
 
 Memory operands can be encoded without a base register, either as an
 absolute address, or an absolute address added to a scaled index
-register.  These operands are always evaluated as offsets relative to
+register.  If these addresses are not used as offsets relative to
+\CFS{} or \CGS{} as described below in Section~\ref{sec:x86:cfs-cgs},
+they are evaluated as offsets relative to
 \DDC{} including in capability mode.
 
 \subsubsection{Direct Memory-Offset MOVs}
@@ -388,6 +390,7 @@ with capability-aware addressing would be reserved and raise a UD\#
 exception.
 
 \subsubsection{Addresses Relative to CFS and CGS}
+\label{sec:x86:cfs-cgs}
 
 Capability-aware addressing must also permit addresses defined as
 offsets relative to \CFS{} and \CGS{} to support TLS with


### PR DESCRIPTION
Recommend deprecating these instructions in capability mode and not extending the immediate memory offsets to support capability immediates.