### PR TITLE
x86: Renumber capability fault error codes.

### DIFF
--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -1068,27 +1068,21 @@ the specific violation.
 \toprule
 Value & Description \\
 \midrule
-0x00 & None \\
-0x01 & Length Violation \\
-0x02 & Tag Violation \\
-0x03 & Seal Violation \\
-0x04 & Type Violation \\
-0x05-0x07 & \emph{reserved} \\
-0x08 & Software-defined Permission Violation \\
-0x09-0x0f & \emph{reserved} \\
-0x10 & \cappermG Violation \\
-0x11 & \cappermX Violation \\
-0x12 & \cappermL Violation \\
-0x13 & \cappermS Violation \\
-0x14 & \cappermLC Violation \\
-0x15 & \cappermSC Violation \\
-0x16 & \cappermSLC Violation \\
-0x17 & \emph{reserved} \\
-0x18 & \cappermASR Violation \\
-0x19 & \cappermInvoke Violation \\
-0x1a-0x1b & \emph{reserved} \\
-0x1c & \cappermCid Violation \\
-0x1d-0x1f & \emph{reserved} \\
+0x0 & Tag Violation \\
+0x1 & Length Violation \\
+0x2 & Seal Violation \\
+0x3 & Type Violation \\
+0x4 & Software-defined Permission Violation \\
+0x5 & \cappermG Violation \\
+0x6 & \cappermX Violation \\
+0x7 & \cappermL Violation \\
+0x8 & \cappermS Violation \\
+0x9 & \cappermLC Violation \\
+0xa & \cappermSC Violation \\
+0xb & \cappermSLC Violation \\
+0xc & \cappermASR Violation \\
+0xd & \cappermInvoke Violation \\
+0xe & \cappermCid Violation \\
 \bottomrule
 \end{tabular}
 \end{center}


### PR DESCRIPTION
- Remove the unused 'None' value.

- Renumber tag violation first since to better match exception priority.

- Collapse error codes to remove gaps.