### PR TITLE
x86: Remove CGetSealed.

### DIFF
--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -798,10 +798,6 @@ otherwise stated.
 
     Set \emph{r64} to the \textbf{tag} field of \emph{r/mc}.
 
-  \item \insnref{CGetSealed} r64, r/mc
-
-    Set \emph{r64} to 1 if \emph{r/mc} is sealed and to 0 otherwise.
-
   \item \insnref{CGetOffset} r64, r/mc
 
     Set \emph{r64} to the \textbf{offset} field of \emph{r/mc}.


### PR DESCRIPTION
Unsealed capabilities use a dedicated object type, so this instruction can be implemented by comparing the result of CGetType.