### PR TITLE
X86 opcodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PREVEOUS=../branches/20150624-cheri-architecture-1-13
 
 SAIL_LATEX_RISCV_DIR=sail_latex_riscv
 
-SOURCES=$(wildcard *.tex insn-riscv/*.tex $(SAIL_LATEX_RISCV_DIR)/*.tex cheri_concentrate_listings/*.bsv cheri_concentrate_listings/*.tex) cheri.bib LICENSE LICENSE-sail-cheri-riscv LICENSE-sail-riscv
+SOURCES=$(wildcard *.tex insn-riscv/*.tex insn-x86-64/*.tex $(SAIL_LATEX_RISCV_DIR)/*.tex cheri_concentrate_listings/*.bsv cheri_concentrate_listings/*.tex) cheri.bib LICENSE LICENSE-sail-cheri-riscv LICENSE-sail-riscv
 DIFFDIR=diff
 DIFFTEX=$(SOURCES:%=${DIFFDIR}/%)
 DIFFPARAM=--type=UNDERLINE --packages=amsmath,hyperref --math-markup=1
@@ -67,6 +67,7 @@ diffdir:
 	@(test -d ${DIFFDIR} || mkdir ${DIFFDIR})
 	@(test -d ${DIFFDIR}/cheri_concentrate_listings || mkdir ${DIFFDIR}/cheri_concentrate_listings)
 	@(test -d ${DIFFDIR}/insn-riscv || mkdir ${DIFFDIR}/insn-riscv)
+	@(test -d ${DIFFDIR}/insn-x86-64 || mkdir ${DIFFDIR}/insn-x86-64)
 	@(test -d ${DIFFDIR}/sail_latex_riscv || mkdir ${DIFFDIR}/sail_latex_riscv)
 
 ${DIFFDIR}/$(TARGET): $(DIFFTEX)

--- a/app-versions-9-0.tex
+++ b/app-versions-9-0.tex
@@ -36,5 +36,6 @@ release of the Version 9 specification:
 \item We have expanded the CHERI-x86-64 sketch in
   Chapter~\ref{chap:cheri-x86-64} to include details on extensions to
   existing instructions to support operations on capabilities as well
-  as details for new instructions.
+  as details for new instructions in a new ISA reference in
+  Chapter~\ref{chap:isaref-x86-64}.
 \end{itemize}

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -692,43 +692,12 @@ If these instructions fail, they should clear the tag in the resulting
 capability.
 
 \begin{itemize}
-  \item \insnref{CSeal} r/mc, rc
-
-    Seal \emph{r/mc} with \textbf{otype} equal to the \textbf{address}
-    field of \empty{rc}.  If the sealing operation fails, set
-    \emph{r/mc} to its original value with the \textbf{tag} field
-    cleared and clear \texttt{ZF}.  If the sealing operation succeeds,
-    set \texttt{ZF} to 1.  The value of other status flags
-    (\texttt{CF}, \texttt{PF}, \texttt{AF}, \texttt{SF}, and
-    \texttt{OF}) would be undefined.
-
-  \item \insnref{CUnSeal} r/mc, rc
-
-    Unseal \emph{r/mc} using \emph{rc} as the authority for the
-    unsealing operation.  If the unsealing operation fails, set
-    \emph{r/mc} to its original value with the \textbf{tag} field
-    cleared and clear \texttt{ZF}.  If the unsealing operation
-    succeeds, set \texttt{ZF} to 1.  The value of other status flags
-    (\texttt{CF}, \texttt{PF}, \texttt{AF}, \texttt{SF}, and
-    \texttt{OF}) would be undefined.
-
-  \item \insnref{CAndPerm} r/mc, r64
-
-    Set the \textbf{perms} and \textbf{uperms} fields of \emph{r/mc}
-    to the bitwise and of the existing field values and \emph{r64}.
-    If \emph{r/mc} is sealed and tagged, set \emph{r/mc} to its
-    original value with the \textbf{tag} field cleared.
-
-  \item \insnref{CSetOffset} r/mc, r64
-
-    Set the \textbf{offset} field of \emph{r/mc} to \emph{r64}.  If
-    \emph{r/mc} is sealed and tagged, set \emph{r/mc} to its original
-    value with the \textbf{tag} field cleared.
-
+  \item \insnxesref{SEAL} - Seal Capability
+  \item \insnxesref{UNSEAL} - Unseal Capability
+  \item \insnxesref{ANDCPERM} - Mask Capability Permissions
+  \item \insnxesref{SCOFF} - Set Capability Offset
   \item \insnxesref{SCADDR} - Set Capability Address
-
   \item \insnxesref{SCBND} - Set Capability Bounds
-
   \item \insnxesref{SCBNDE} - Set Exact Capability Bounds
 
   \item \insnref{CClearTag} r/mc

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -782,6 +782,9 @@ extensions:
      is a number between 0 and 65,535 inclusive.
 \end{itemize}
 
+Note that all of these instructions would only be valid in 64-bit mode
+and capability mode.
+
 \subsubsection{Capability-Inspection Instructions}
 
 These instructions would set the \texttt{ZF} flag in \RFLAGS{}

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -818,11 +818,7 @@ capability.
     \emph{r/mc} is sealed and tagged, set \emph{r/mc} to its original
     value with the \textbf{tag} field cleared.
 
-  \item \insnref{CSetAddr} r/mc, r64
-
-    Set the \textbf{address} field of \emph{r/mc} to \emph{r64}.  If
-    \emph{r/mc} is sealed and tagged, set \emph{r/mc} to its original
-    value with the \textbf{tag} field cleared.
+  \item \insnxesref{SCADDR} - Set Capability Address
 
   \item \insnref{CSetBounds} r/mc, r64
   \item \insnref{CSetBounds} r/mc, uimm16
@@ -1249,12 +1245,12 @@ implemented as the addresses of the appropriate capability register.
 Reads of the \FSBASE{}, \GSBASE{}, and \KGSBASE{} MSRs should return
 the address of the \CFS{}, \CGS{}, and \KGS{} capabilities,
 respectively.  Writes to these MSRs should set the address of the
-respective capability equivalent to \insnref{CSetAddr}.  Similarly,
+respective capability equivalent to \insnxesref{SCADDR}.  Similarly,
 the \insnnoref{RDFSBASE} and \insnnoref{RDGSBASE} instructions should
 return the address of the \CFS{} and \CGS{} capabilities,
 respectively.  The \insnnoref{WRFSBASE} and \insnnoref{WRGSBASE}
 instructions should set the address of the respective capability
-equivalent to \insnref{CSetAddr}.  If a new address is set which makes
+equivalent to \insnxesref{SCADDR}.  If a new address is set which makes
 the capability unrepresentable, the capability's tag should be
 cleared.
 

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -700,46 +700,9 @@ capability.
   \item \insnxesref{SCBND} - Set Capability Bounds
   \item \insnxesref{SCBNDE} - Set Exact Capability Bounds
   \item \insnxesref{CLCTAG} - Clear Capability Tag
-
-  \item \insnref{CBuildCap} rca, r/mc, rcb
-
-    Set \emph{rca} equal to \emph{r/mc} with the \textbf{base},
-    \textbf{length}, \textbf{address}, \textbf{perms}, and
-    \textbf{uperms} fields replaced with the corresponding fields in
-    \emph{rcb}.  If \emph{rcb} is a sentry then \emph{rca} is also
-    sealed as a sentry.  If \emph{r/mc} does not authorize the
-    construction of the desired capability, set \emph{rca} equal to
-    \emph{rcb} with the \textbf{tag} field cleared.
-
-    Set \texttt{ZF} in \RFLAGS{} to the value of \textbf{tag} field
-    of \emph{rca}.  The value of other status flags (\texttt{CF},
-    \texttt{PF}, \texttt{AF}, \texttt{SF}, and \texttt{OF}) would be
-    undefined.
-
-  \item \insnref{CCopyType} rca, r/mc, rcb
-
-    Set \emph{rca} to \emph{r/mc} with the \textbf{address} field set
-    to \emph{rcb}.\textbf{otype}.  On failure (including if the
-    \textbf{otype} field of \emph{rcb} is a reserved value), set
-    \emph{rca} to the \textbf{NULL} capability with the
-    \textbf{address} field set to \emph{rcb}.\textbf{otype}.
-
-    Set \texttt{ZF} in \RFLAGS{} to the value of \textbf{tag} field
-    of \emph{rca}.  The value of other status flags (\texttt{CF},
-    \texttt{PF}, \texttt{AF}, \texttt{SF}, and \texttt{OF}) would be
-    undefined.
-
-  \item \insnref{CCSeal} rca, r/mc, rcb
-
-    Set \emph{rca} to \emph{r/mc} conditionally sealed with
-    \textbf{otype} equal to the \textbf{address} field of \emph{rcb}.
-    If \emph{rca} is not sealed with \emph{rcb}.\textbf{otype}, it
-    will be set equal to \emph{r/mc}.  Set \texttt{ZF} in \RFLAGS{} to
-    1 if \emph{rca} is sealed with \emph{rcb}.\textbf{otype} or 0
-    otherwise.  The value of other status flags (\texttt{CF},
-    \texttt{PF}, \texttt{AF}, \texttt{SF}, and \texttt{OF}) would be
-    undefined.
-
+  \item \insnxesref{BUILDCAP} - Construct Capability
+  \item \insnxesref{CPYTYPE} - Construct Sealing Capability
+  \item \insnxesref{CSEAL} - Conditional Capability Seal
   \item \insnxesref{SENTRY} - Seal Capability as a Sentry
 \end{itemize}
 

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -731,49 +731,23 @@ and capability mode.
 
 \subsubsection{Capability-Inspection Instructions}
 
-These instructions would set the \texttt{ZF} flag in \RFLAGS{}
-according to the integer field
-extracted from the capability.
-The value of other status flags (\texttt{CF}, \texttt{PF},
-\texttt{AF}, \texttt{SF}, and \texttt{OF}) would be undefined unless
-otherwise stated.
-
+These instructions fetch a single field from a capability.
 Note that unlike CHERI-RISC-V, CHERI-x86-64 would not add a
 \insnref{CGetAddr} instruction since the \textbf{address} field of a
 capability can be obtained via a 64-bit \insnnoref{MOV} instruction.
 
 \begin{itemize}
-  \item \insnref{CGetPerm} r64, r/mc
-
-    Set \emph{r64} to the combined \textbf{perms} and \textbf{uperms}
-    fields of \emph{r/mc}.
-
-  \item \insnref{CGetType} r64, r/mc
-
-    Set \emph{r64} to the \textbf{otype} field of \emph{r/mc}.  In
-    addition to \texttt{ZF}, this instruction should also set
-    \texttt{SF} in \RFLAGS{}.
-
-  \item \insnref{CGetBase} r64, r/mc
-
-    Set \emph{r64} to the \textbf{base} field of \emph{r/mc}.
-
-  \item \insnref{CGetLen} r64, r/mc
-
-    Set \emph{r64} to the \textbf{length} field of \emph{r/mc}.
-
-  \item \insnref{CGetTag} r64, r/mc
-
-    Set \emph{r64} to the \textbf{tag} field of \emph{r/mc}.
-
-  \item \insnref{CGetOffset} r64, r/mc
-
-    Set \emph{r64} to the \textbf{offset} field of \emph{r/mc}.
+  \item \insnxesref{GCPERM} - Get Capability Permissions
+  \item \insnxesref{GCTYPE} - Get Capability Object Type
+  \item \insnxesref{GCBASE} - Get Capability Base
+  \item \insnxesref{GCLEN} - Get Capability Length
+  \item \insnxesref{GCTAG} - Get Capability Tag
+  \item \insnxesref{GCOFF} - Get Capability Offset
 \end{itemize}
 
 Additionally, to support efficient tag checks without overwriting an
-integer register with the result as is done in \insnref{CGetTag}, a
-single operand \insnnoref{CTestTag} which copies the tag value to
+integer register with the result as is done in \insnxesref{GCTAG}, a
+single operand \insnnoref{TESTCTAG} which copies the tag value to
 \texttt{ZF} may be desired.
 
 \subsubsection{Capability-Modification Instructions}

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -699,10 +699,7 @@ capability.
   \item \insnxesref{SCADDR} - Set Capability Address
   \item \insnxesref{SCBND} - Set Capability Bounds
   \item \insnxesref{SCBNDE} - Set Exact Capability Bounds
-
-  \item \insnref{CClearTag} r/mc
-
-    Clear the \textbf{tag} field of \emph{r/mc}.
+  \item \insnxesref{CLCTAG} - Clear Capability Tag
 
   \item \insnref{CBuildCap} rca, r/mc, rcb
 
@@ -743,13 +740,7 @@ capability.
     \texttt{PF}, \texttt{AF}, \texttt{SF}, and \texttt{OF}) would be
     undefined.
 
-  \item \insnref{CSealEntry} r/mc
-
-    Seal \emph{r/mc} as a sentry.  On failure, leave \emph{r/mc}
-    unchanged.  Set \texttt{ZF} in \RFLAGS{} to 1 if \emph{r/mc} if
-    \emph{r/mc} is sealed as a sentry or 0 otherwise.  The value of
-    other status flags (\texttt{CF}, \texttt{PF}, \texttt{AF},
-    \texttt{SF}, and \texttt{OF}) would be undefined.
+  \item \insnxesref{SENTRY} - Seal Capability as a Sentry
 \end{itemize}
 
 \subsubsection{Control-Flow Instructions}
@@ -792,18 +783,7 @@ returned by an existing \insnnoref{CPUID} leaf.
     Fault (see Section~\ref{sec:x86:capability-fault}) or a Page
     Fault.
 
-  \item \insnref{CClearTags} m
-
-    Clear the memory tags for a stride of capabilities located in
-    memory at and above the memory addressed by \emph{m}.  The
-    authorizing capability for \emph{m} must include \cappermS{} and
-    authorize access to the entire stride of
-    capabilities.  The address of \emph{m} must also be aligned to a
-    stride of capabilities.
-
-    If this instruction fails, it raises either a Capability Violation
-    Fault (see Section~\ref{sec:x86:capability-fault}) or a Page
-    Fault.
+  \item \insnxesref{CLCTAGS} - Clear Capability Tags
 \end{itemize}
 
 \subsection{Interactions with Vector Extensions}

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -514,14 +514,8 @@ capability operands:
     \insnnoref{SCAS} with support for capability operands.  If that
     did prove necessary, they could be extended.
 
-  \item \insnnoref{CMOVC} would handle conditional loads and stores of
-    capabilities.  Existing opcodes for \insnnoref{CMOV} would be
-    extended to support capability operands via the capability operand
-    prefix.  Note that this would support only moves to and from
-    general-purpose capability registers.
-
-    \insnnoref{CMOV} should default to integer operands in
-    capability mode.
+  \item \insnxesref[cmov]{CMOVC} would handle conditional loads and stores of
+    capabilities.
 
   \item \insnnoref{ADDC} and \insnnoref{SUBC} would be used to adjust
     the offset of a capability similar to \insnref{CIncOffset}.  Note

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -503,16 +503,8 @@ capability operands:
     \DDC{} in all privilege levels.  Access to other additional
     capability registers would be permitted only in privilege level 0.
 
-  \item \insnnoref{MOVNTIC} would store a single capability to memory
+  \item \insnxesref[movnti]{MOVNTIC} would store a single capability to memory
     using a non-temporal hint.
-
-    The existing \texttt{0F C3} opcode would be extended to support
-    capability operands via the capability operand prefix.  Note that
-    this would support only stores of general-purpose capability
-    registers.
-
-    \insnnoref{MOVNTI} should default to integer operands in
-    capability mode.
 
   \item The string instructions \insnnoref{LODS}, \insnnoref{MOVS},
     and \insnnoref{STOS} would be extended to support capability
@@ -1045,7 +1037,7 @@ Blocks of data stored to memory mapped with write-combining (WC) are
 often written via non-temporal vector register stores.  However, such
 data is generally consumed by an I/O device via DMA and rarely
 contains pointers.  We believe that permitting a non-temporal store of
-a single capability via \insnnoref{MOVNTIC} is sufficient for cases
+a single capability via \insnxesref[movnti]{MOVNTIC} is sufficient for cases
 requiring non-temporal stores of tagged capabilities.
 
 \subsubsection{Memory Addressing}

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -883,17 +883,8 @@ capability.
   Instructions}
 
 \begin{itemize}
-  \item \insnref{CRRL} r64, r/m64
-
-    Set \emph{r64} to the smallest value greater or equal to
-    \emph{r/m64} that can be used as a length to set exact bounds on a
-    capability with a suitably aligned base.
-
-  \item \insnref{CRAM} r64, r/m64
-
-    Set \emph{r64} to a mask that can be used to round addresses down
-    to a value that is sufficiently aligned to set exact bounds for
-    the nearest representable length of \emph{r/m64}.
+  \item \insnxesref{CRRL} - Round Representable Length
+  \item \insnxesref{CRAM} - Representable Alignment Mask
 \end{itemize}
 
 \subsubsection{Tag-Memory Access Instructions}

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -430,7 +430,7 @@ mode, \RSP{} is always used as the stack pointer.  In capability mode,
 \CSP{} would always be used as the stack pointer.
 
 Code which needs to use the alternate stack pointer
-interpretation would simulate these instructions using \insnnoref{MOV}
+interpretation would simulate these instructions using \insnxesref{MOV}
 instructions and adjusting the desired stack pointer using
 instructions such as \insnnoref{ADD} or \insnnoref{SUB}.  Emulation of
 \insnnoref{CALL} or \insnnoref{RET} would use \insnnoref{JMP} to
@@ -492,35 +492,16 @@ Several existing instructions should be extended to support
 capability operands:
 
 \begin{itemize}
-  \item \insnnoref{MOVC} would handle loads and stores of
-    capabilities similar to \insnref{CLC} and \insnref{CSC} as well as
-    copying capabilities between registers similar to \insnref{CMove}.
-
-    The existing \texttt{89} and \texttt{8B} opcodes would be extended
-    to support capability operands via the capability operand prefix.
-    Note that these instructions would  permit a general-purpose
-    register only as the source (\texttt{89}) or destination (\texttt{8B}).
-
-    The \texttt{A1} and \texttt{A3} opcodes would not be extended to
-    support capabilities.
+  \item \insnxesref[mov]{MOVC} would handle loads and stores of
+    capabilities similar to \insnriscvref{CLC} and \insnriscvref{CSC} as well as
+    copying capabilities between registers similar to \insnriscvref{CMove}.
 
     To permit moving the contents of an additional capability register
-    to a general-purpose register or vice versa, two
-    new opcodes (\texttt{0F 24} and \texttt{0F 25}) would be
+    to a general-purpose register or vice versa, two new
+    \insnxesref[movcap]{MOV} opcodes would be
     used.  These opcodes would permit access to \CFS{}, \CGS{}, and
     \DDC{} in all privilege levels.  Access to other additional
     capability registers would be permitted only in privilege level 0.
-
-    To support efficiently storing NULL pointers to memory, the \texttt{C7 /0}
-    opcode would be extended to support capability operands via
-    the capability operand prefix.  When extended to a capability
-    operand, this instruction should store a NULL-derived capability
-    using the immediate operand sign-extended to 64 bits as the
-    integer value of the resulting capability.
-
-    \insnnoref{MOV} should default to integer operands in capability
-    mode except for \texttt{0F 24} and \texttt{0F 25} which would
-    always use capability operands.
 
   \item \insnnoref{MOVNTIC} would store a single capability to memory
     using a non-temporal hint.
@@ -1051,7 +1032,7 @@ may require additional care.
 
 Vector loads and stores are often used to implement \ccode{memcpy()}.
 In CHERI C, \ccode{memcpy()} must preserve tags.  A \ccode{memcpy()}
-implementation which uses \insnnoref{MOVC} will operate at the same
+implementation which uses \insnxesref[mov]{MOVC} will operate at the same
 width as existing memory copies implemented using SSE which may
 mitigate some of the cost.  Another option may be to support an
 optimized \insnnoref{REP MOVSC} similar to the existing optimization
@@ -1401,7 +1382,7 @@ optimize pure capability code.
 We considered various options for using additional capability
 registers such as \CGS{} as explicit operands in instructions rather
 than as a separate bank of registers accessed only via
-\insnnoref{MOV}.  All of these approaches add complexity to
+\insnxesref[movcap]{MOV}.  All of these approaches add complexity to
 instruction decoding, but we do not anticipate frequent direct access
 to additional capability registers beyond the use of the existing
 \FS{} and \GS{} segment prefixes.

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -410,7 +410,7 @@ capabilities.
 The ``string''
 instructions use \RSI{} as source address and \RDI{} as a destination address.
 For example, the
-\insnnoref{STOS} instruction stores the value in \AL{}/\AX{}/\EAX{}/\RAX{} to the address in
+\insnxesref{STOS} instruction stores the value in \AL{}/\AX{}/\EAX{}/\RAX{} to the address in
 \RDI{}, and then either increments or decrements the destination
 index register (depending on the Direction Flag).  When capability
 addressing mode is enabled,
@@ -506,21 +506,13 @@ capability operands:
   \item \insnxesref[movnti]{MOVNTIC} would store a single capability to memory
     using a non-temporal hint.
 
-  \item The string instructions \insnnoref{LODS}, \insnnoref{MOVS},
-    and \insnnoref{STOS} would be extended to support capability
+  \item The string instructions \insnxesref{LODS}, \insnxesref{MOVS},
+    and \insnxesref{STOS} would be extended to support capability
     operands.
-
-    The opcodes \texttt{A5}, \texttt{AB}, and \texttt{AD} would be
-    extended to support capability operands via the capability operand
-    prefix.  For \insnnoref{LODSC} and \insnnoref{STOSC}, \CAX{} would
-    be used as the implicit operand.
-
-    These instructions should default to integer operands in
-    capability mode.
 
     We do not currently foresee a need to extend \insnnoref{CMPS} and
     \insnnoref{SCAS} with support for capability operands.  If that
-    did prove necessary, they could be extended in the same manner.
+    did prove necessary, they could be extended.
 
   \item \insnnoref{CMOVC} would handle conditional loads and stores of
     capabilities.  Existing opcodes for \insnnoref{CMOV} would be
@@ -1027,7 +1019,7 @@ In CHERI C, \ccode{memcpy()} must preserve tags.  A \ccode{memcpy()}
 implementation which uses \insnxesref[mov]{MOVC} will operate at the same
 width as existing memory copies implemented using SSE which may
 mitigate some of the cost.  Another option may be to support an
-optimized \insnnoref{REP MOVSC} similar to the existing optimization
+optimized \insnxesref[movs]{REP MOVSC} similar to the existing optimization
 for \insnnoref{REP MOVSB} where the former instruction would preserve
 tags during a copy unlike the latter.
 

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -581,22 +581,16 @@ add %csp,$16
     \insnnoref{PUSH} and \insnnoref{POP} should default to capability
     operands in capability mode.
 
-  \item \insnnoref{LEAC} would store the resulting address in a
+  \item \insnxesref[lea]{LEAC} would store the resulting address in a
     destination capability register.
 
-    The opcode \texttt{8D} would be extended to support capability
-    operands via the capability operand prefix.
-
-    \insnnoref{LEA} would not support the 0x07 opcode prefix.  The
+    \insnxesref{LEA} would not support the 0x07 opcode prefix.  The
     address size would always match the operand size.  Storing an
     integer address in a capability register would have the same
-    effect as the equivalent version of \insnnoref{LEA} storing the
+    effect as the equivalent version of \insnxesref{LEA} storing the
     integer address to the integer alias register.  Using a
-    capability-aware address with an integer \insnnoref{LEA} would
+    capability-aware address with an integer \insnxesref{LEA} would
     also be identical in effect to using ``plain'' addressing.
-
-    \insnnoref{LEA} should default to integer operands in
-    capability mode.
 
   \item \insnnoref{ENTER} and \insnnoref{LEAVE} could be extended to
     support implicit capability operands, or they could be deprecated

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -551,53 +551,24 @@ add %csp,$16
     We do not anticipate a need for a capability-sized variant of
     \insnnoref{TEST}.
 
-  \item \insnnoref{CMPXCHGC} will be required to support atomic
+  \item \insnxesref[cmpxchg]{CMPXCHGC} will be required to support atomic
     operations on capabilities.  (Note that \insnnoref{CMPXCHG16B}'s
     existing semantics are not suitable for capabilities as it divides
     the values into register pairs.)
 
-    The opcodes \texttt{0F B0} and \texttt{0F B1} would be extended to
-    support capability operands via the capability operand prefix.
-
-    \insnnoref{CMPXCHG} should default to integer operands in
-    capability mode.
-
-  \item \insnnoref{CMPXCHG2C} will be required to support atomic
+  \item \insnxesref{CMPXCHG2C} will be required to support atomic
     operations on pairs of capabilities.
 
-    The opcode \texttt{0F C7 /1} would be extended to support
-    capability operands via the capability operand prefix.
-
-    \insnnoref{CMPXCHG16B} should default to integer operands in
-    capability mode.
-
-  \item \insnnoref{XCHGC} will also be required to support atomic
+  \item \insnxesref[xchg]{XCHGC} will also be required to support atomic
     operations on capabilities.
 
-    The opcodes \texttt{87} and \texttt{90 + rd} would be extended to
-    support capability operands via the capability operand prefix.
-    The specific opcode \texttt{90} would remain a single byte
-    \insnnoref{NOP} which would not alter the value of \CAX{}.
-
-    \insnnoref{XCHG} should default to integer operands in capability
-    mode.
-
-  \item It may also be desirable to support \insnnoref{XADDC}.  For
+  \item It may also be desirable to support \insnxesref[xadd]{XADDC}.  For
     this instruction, only the integer portion of the second (source)
-    operand would be added to the integer value of the first
+    operand would be added to the first
     (destination) operand to determine the value stored to the
     destination.  Any tag or capability metadata in the second operand
     would be ignored and would be overwritten with the original value
     of the first operand.
-
-    The opcode \texttt{0F C0} would be extended to support capability
-    operands via the capability operand prefix.
-
-    \insnnoref{XADDC} should set status flag bits in \RFLAGS{}
-    according to the integer value of the resulting capability.
-
-    \insnnoref{XADD} should default to integer operands in
-    capability mode.
 
   \item \insnnoref{PUSHC} and \insnnoref{POPC} would be used to save
     and restore capability registers on the stack.
@@ -1343,5 +1314,5 @@ in capability mode rather than removed.
 
 \subsection{XCHG [ER]AX Opcodes}
 
-If the \insnnoref{XCHG} instructions \texttt{91} - \texttt{97} are not
+If the \insnxesref{XCHG} instructions \texttt{91} - \texttt{97} are not
 commonly used, they could be removed in capability mode.

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -731,21 +731,7 @@ a new \insnnoref{CPUID} leaf or be defined as equal to the value
 returned by an existing \insnnoref{CPUID} leaf.
 
 \begin{itemize}
-  \item \insnref{CLoadTags} r64, m
-
-    Set \emph{r64} to a bitmask of tags for a stride of capabilities
-    located in memory at and above the memory addressed by \emph{m}.
-    Bit 0 corresponds to tag for the capability at the address
-    \emph{m}.  The authorizing capability for \emph{m} (either \DDC{}
-    or an explicit capability register as the base address register)
-    must include \cappermL{} and \cappermLC{} and authorize access to
-    the entire stride of capabilities.  The address of \emph{m} must
-    also be aligned to a stride of capabilities.
-
-    If this instruction fails, it raises either a Capability Violation
-    Fault (see Section~\ref{sec:x86:capability-fault}) or a Page
-    Fault.
-
+  \item \insnxesref{LCTAGS} - Load Capability Tags
   \item \insnxesref{CLCTAGS} - Clear Capability Tags
 \end{itemize}
 

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -724,9 +724,6 @@ extensions:
   \item \textbf{r/mc} { }---{ } A capability operand that is either
     the contents of one of the capability registers for \textbf{rc} or
     a capability in memory.
-
-   \item \textbf{uimm16} { }---{ } An unsigned immediate value.  This
-     is a number between 0 and 65,535 inclusive.
 \end{itemize}
 
 Note that all of these instructions would only be valid in 64-bit mode
@@ -820,38 +817,9 @@ capability.
 
   \item \insnxesref{SCADDR} - Set Capability Address
 
-  \item \insnref{CSetBounds} r/mc, r64
-  \item \insnref{CSetBounds} r/mc, uimm16
+  \item \insnxesref{SCBND} - Set Capability Bounds
 
-    Set the \textbf{base} field of \emph{r/mc} to the current
-    \textbf{address} field of \emph{r/mc}, and set the \textbf{length}
-    field of \emph{r/mc} to the second operand.  If the \emph{r/mc} is
-    sealed and tagged, set \emph{r/mc} to its original value with the
-    \textbf{tag} field cleared.  If the resulting capability is not
-    contained within the bounds of the original value of \emph{r/mc},
-    clear the \textbf{tag} field in the resulting capability.
-
-    Set \texttt{ZF} in \RFLAGS{} to the value of \textbf{tag} field
-    in the resulting value of \emph{r/mc}.   The value of other status
-    flags (\texttt{CF}, \texttt{PF}, \texttt{AF}, \texttt{SF}, and
-    \texttt{OF}) would be undefined.
-
-  \item \insnref{CSetBoundsExact} r/mc, r64
-
-    Set the \textbf{base} field of \emph{r/mc} to the current
-    \textbf{address} field of \emph{r/mc}, and set the \textbf{length}
-    field of \emph{r/mc} to \emph{r64}.  If the \emph{r/mc} is sealed
-    and tagged, set \emph{r/mc} to its original value with the
-    \textbf{tag} field cleared.  If the resulting capability is not
-    contained within the bounds of the original value of \emph{r/mc},
-    clear the \textbf{tag} field in the resulting capability.  If the
-    resulting capability cannot be represented exactly, clear the
-    \textbf{tag} field in the resulting capability.
-
-    Set \texttt{ZF} in \RFLAGS{} to the value of \textbf{tag} field
-    in the resulting value of \emph{r/mc}.  The value of other status
-    flags (\texttt{CF}, \texttt{PF}, \texttt{AF}, \texttt{SF}, and
-    \texttt{OF}) would be undefined.
+  \item \insnxesref{SCBNDE} - Set Exact Capability Bounds
 
   \item \insnref{CClearTag} r/mc
 

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -540,7 +540,7 @@ add %csp,$16
     with \insnxesref[add]{ADDC}, the second operand would always be an
     integer operand.
 
-  \item \insnnoref{CMPC} would permit comparison of capability values
+  \item \insnxesref[cmp]{CMPC} would permit comparison of capability values
     including the functionality of both \insnref{CSetEqualExact} (via
     \texttt{ZF}) and \insnref{CTestSubset} (via \texttt{SF}).  This is
     somewhat different than the existing variants of \insnnoref{CMP}
@@ -548,15 +548,8 @@ add %csp,$16
     discard the result as in this case the flags set would not be
     identical to the flags set as a result of \insnxesref[sub]{SUBC}.
 
-    The \insnnoref{CMP} opcodes \texttt{39} and \texttt{3B} would be
-    extended to support capability operands via the capability operand
-    prefix.
-
     We do not anticipate a need for a capability-sized variant of
     \insnnoref{TEST}.
-
-    \insnnoref{CMP} should default to integer operands in capability
-    mode.
 
   \item \insnnoref{CMPXCHGC} will be required to support atomic
     operations on capabilities.  (Note that \insnnoref{CMPXCHG16B}'s

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -876,14 +876,7 @@ capability.
 \subsubsection{Control-Flow Instructions}
 
 \begin{itemize}
-  \item \insnref{CInvoke} rc, r/mc
-
-    If \emph{rc} and \emph{r/mc} are sealed with the same
-    \textbf{otype}, set \CIP{} to the unsealed \emph{rc} and set
-    \CAX{} to the unsealed \emph{r/mc}.  Note that this control
-    transfer is a jump and does not push any values onto the stack.
-    If this instruction fails, it raises a Capability Violation Fault
-    (see Section~\ref{sec:x86:capability-fault}).
+  \item \insnxesref{CINVOKE} - Invoke sealed capability pair
 \end{itemize}
 
 \subsubsection{Adjusting to Compressed Capability Precision

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -422,7 +422,7 @@ using capability-aware addressing.
 
 \subsubsection{Stack Address Size}
 
-Instructions that work with the stack such as \insnnoref{PUSH} or
+Instructions that work with the stack such as \insnxesref{PUSH} or
 \insnnoref{CALL} use the stack pointer as an implicit operand.  In
 32-bit x86, the `B' flag of the stack segment selector determines if
 the 16-bit or 32-bit stack pointer register is used.  In 64-bit long
@@ -570,16 +570,8 @@ add %csp,$16
     would be ignored and would be overwritten with the original value
     of the first operand.
 
-  \item \insnnoref{PUSHC} and \insnnoref{POPC} would be used to save
+  \item \insnxesref[push]{PUSHC} and \insnxesref[pop]{POPC} would be used to save
     and restore capability registers on the stack.
-
-    The \insnnoref{PUSH} opcodes \texttt{50} and \texttt{FF / 0} and the
-    \insnnoref{POP} opcodes \texttt{58} and \texttt{8F / 0} would be
-    extended to support capability operands via the capability operand
-    prefix.
-
-    \insnnoref{PUSH} and \insnnoref{POP} should default to capability
-    operands in capability mode.
 
   \item \insnxesref[lea]{LEAC} would store the resulting address in a
     destination capability register.

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -648,20 +648,6 @@ CHERI instructions, most instructions are defined with two operands
 rather than three.  New instructions which require three operands must
 be encoded using a \VEX{} prefix.
 
-Operands are described using the syntax from Volume 2 of Intel's
-Software Developer's Manual~\cite{intel-sdm-vol2} with the following
-extensions:
-
-\begin{itemize}
-  \item \textbf{rc} { }---{ } One of the general-purpose capability
-    registers: \CAX{}, \CBX{}, \CCX{}, \CDX{}, \CDI{}, \CSI{}, \CBP{},
-    \CSP{}, \creg{8}-\creg{15}.
-
-  \item \textbf{r/mc} { }---{ } A capability operand that is either
-    the contents of one of the capability registers for \textbf{rc} or
-    a capability in memory.
-\end{itemize}
-
 Note that all of these instructions would only be valid in 64-bit mode
 and capability mode.
 

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -432,7 +432,7 @@ mode, \RSP{} is always used as the stack pointer.  In capability mode,
 Code which needs to use the alternate stack pointer
 interpretation would simulate these instructions using \insnxesref{MOV}
 instructions and adjusting the desired stack pointer using
-instructions such as \insnnoref{ADD} or \insnnoref{SUB}.  Emulation of
+instructions such as \insnxesref{ADD} or \insnxesref{SUB}.  Emulation of
 \insnnoref{CALL} or \insnnoref{RET} would use \insnnoref{JMP} to
 adjust the instruction pointer.
 
@@ -517,11 +517,11 @@ capability operands:
   \item \insnxesref[cmov]{CMOVC} would handle conditional loads and stores of
     capabilities.
 
-  \item \insnnoref{ADDC} and \insnnoref{SUBC} would be used to adjust
-    the offset of a capability similar to \insnref{CIncOffset}.  Note
+  \item \insnxesref[add]{ADDC} and \insnxesref[sub]{SUBC} would be used to adjust
+    the address of a capability similar to \insnriscvref{CIncOffset}.  Note
     that for these instructions, the source operand would either be a
     sign-extended immediate or a 64-bit integer register whose value
-    is either added to or subtracted from the offset of the
+    is either added to or subtracted from the address of the
     capability-sized destination operand.
 
     For example:
@@ -532,24 +532,12 @@ add %csp,$16
 
     would move the capability stack pointer up by 16 bytes.
 
-    These instructions should set status flag bits in \RFLAGS{}
-    according to the integer value of the resulting capability.
-
-    The \insnnoref{ADD} opcodes \texttt{01}, \texttt{03}, \texttt{05},
-    \texttt{81 /0}, and \texttt{83 /0} and the \insnnoref{SUB}
-    opcodes \texttt{29}, \texttt{2B}, \texttt{2D}, \texttt{81 /5} and
-    \texttt{83 /5} would be extended to support capability operands
-    via the capability operand prefix.
-
-    \insnnoref{ADD} and \insnnoref{SUB} should default to integer
-    operands in capability mode.
-
     We do not anticipiate a need for capability-sized variants of
     \insnnoref{ADC} or \insnnoref{SBB}.
 
   \item \insnnoref{ANDC}, \insnnoref{ORC}, and \insnnoref{XORC} would
     permit bit manipulation of the integer value of a capability.  As
-    with \insnnoref{ADDC}, the second operand would always be an
+    with \insnxesref[add]{ADDC}, the second operand would always be an
     integer operand.
 
     These instructions should set status flag bits in \RFLAGS{}
@@ -572,7 +560,7 @@ add %csp,$16
     somewhat different than the existing variants of \insnnoref{CMP}
     which perform the equivalent \insnnoref{SUB} instruction and then
     discard the result as in this case the flags set would not be
-    identical to the flags set as a result of \insnnoref{SUBC}.
+    identical to the flags set as a result of \insnxesref[sub]{SUBC}.
 
     The \insnnoref{CMP} opcodes \texttt{39} and \texttt{3B} would be
     extended to support capability operands via the capability operand

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -423,7 +423,7 @@ using capability-aware addressing.
 \subsubsection{Stack Address Size}
 
 Instructions that work with the stack such as \insnxesref{PUSH} or
-\insnnoref{CALL} use the stack pointer as an implicit operand.  In
+\insnxesref{CALL} use the stack pointer as an implicit operand.  In
 32-bit x86, the `B' flag of the stack segment selector determines if
 the 16-bit or 32-bit stack pointer register is used.  In 64-bit long
 mode, \RSP{} is always used as the stack pointer.  In capability mode,
@@ -433,7 +433,7 @@ Code which needs to use the alternate stack pointer
 interpretation would simulate these instructions using \insnxesref{MOV}
 instructions and adjusting the desired stack pointer using
 instructions such as \insnxesref{ADD} or \insnxesref{SUB}.  Emulation of
-\insnnoref{CALL} or \insnnoref{RET} would use \insnnoref{JMP} to
+\insnxesref{CALL} or \insnxesref{RET} would use \insnxesref{JMP} to
 adjust the instruction pointer.
 
 \subsection{Capability-Aware Instructions}
@@ -636,7 +636,7 @@ code segment.
 
 Note that attempting to push or pop a misaligned capability will raise
 an exception.  The stack pointer must be suitably aligned before the
-use of \insnnoref{CALLC}, \insnnoref{IRETC}, and \insnnoref{RETC}.
+use of \insnxesref[call]{CALLC}, \insnnoref{IRETC}, and \insnxesref[ret]{RETC}.
 
 \subsection{New CHERI Instructions}
 

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -535,24 +535,10 @@ add %csp,$16
     We do not anticipiate a need for capability-sized variants of
     \insnnoref{ADC} or \insnnoref{SBB}.
 
-  \item \insnnoref{ANDC}, \insnnoref{ORC}, and \insnnoref{XORC} would
+  \item \insnxesref[and]{ANDC}, \insnxesref[or]{ORC}, and \insnxesref[xor]{XORC} would
     permit bit manipulation of the integer value of a capability.  As
     with \insnxesref[add]{ADDC}, the second operand would always be an
     integer operand.
-
-    These instructions should set status flag bits in \RFLAGS{}
-    according to the integer value of the resulting capability.
-
-    The \insnnoref{AND} opcodes \texttt{21}, \texttt{23}, \texttt{25},
-    \texttt{81 /4} and \texttt{83 /4}; the \insnnoref{OR} opcodes
-    \texttt{09}, \texttt{0B}, \texttt{0D}, \texttt{81 /1}, and
-    \texttt{81 /3}; and the \insnnoref{XOR} opcodes \texttt{31},
-    \texttt{33}, \texttt{35}, \texttt{81 /6}, and \texttt{83 /6} would
-    be extended to support capability operands via the capability
-    operand prefix.
-
-    \insnnoref{AND}, \insnnoref{OR}, and \insnnoref{XOR} should
-    default to integer operands in capability mode.
 
   \item \insnnoref{CMPC} would permit comparison of capability values
     including the functionality of both \insnref{CSetEqualExact} (via

--- a/chap-intro.tex
+++ b/chap-intro.tex
@@ -759,6 +759,11 @@ CHERI-RISC-V instruction.
 
 \medskip
 \noindent
+Chapter~\ref{chap:isaref-x86-64} provides a detailed description of each
+CHERI-x86-64 instruction.
+
+\medskip
+\noindent
 Chapter~\ref{chap:rationale} discusses the design rationale for many aspects
 of the CHERI ISA, as well as our thoughts on future refinements based on
 lessons learned to date.

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -86,6 +86,7 @@ between the base instructions and their CHERI extensions.
 \input{insn-x86-64/add}
 \input{insn-x86-64/and}
 \input{insn-x86-64/cmov}
+\input{insn-x86-64/cmp}
 \input{insn-x86-64/lods}
 \input{insn-x86-64/mov}
 \input{insn-x86-64/movnti}

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -104,6 +104,12 @@ frequently-accessed code paths.
 \input{insn-x86-64/cinvoke}
 \input{insn-x86-64/cram}
 \input{insn-x86-64/crrl}
+\input{insn-x86-64/gcbase}
+\input{insn-x86-64/gclen}
+\input{insn-x86-64/gcoff}
+\input{insn-x86-64/gcperm}
+\input{insn-x86-64/gctag}
+\input{insn-x86-64/gctype}
 \input{insn-x86-64/movcap}
 \input{insn-x86-64/scaddr}
 \input{insn-x86-64/scbnd}
@@ -139,5 +145,17 @@ available in capability mode.
   0F 24 \emph{/r} & \insnxesref[movcap]{MOV} \emph{rc,} CFS/CGS/DDC\\
   \hline
   0F 25 \emph{/r} & \insnxesref[movcap]{MOV} CFS/CGS/DDC\emph{, rc}\\
+  \hline
+  NP 0F 7A \emph{/r} & \insnxesref{GCPERM} \emph{r64, r/mc}\\
+  \hline
+  66 0F 7A \emph{/r} & \insnxesref{GCTYPE} \emph{r64, r/mc}\\
+  \hline
+  F2 0F 7A \emph{/r} & \insnxesref{GCBASE} \emph{r64, r/mc}\\
+  \hline
+  F3 0F 7A \emph{/r} & \insnxesref{GCLEN} \emph{r64, r/mc}\\
+  \hline
+  NP 0F 7B \emph{/r} & \insnxesref{GCTAG} \emph{r64, r/mc}\\
+  \hline
+  66 0F 7B \emph{/r} & \insnxesref{GCOFF} \emph{r64, r/mc}\\
   \hline
 \end{tabular}

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -96,6 +96,7 @@ between the base instructions and their CHERI extensions.
 \input{insn-x86-64/cmp}
 \input{insn-x86-64/cmpxchg}
 \input{insn-x86-64/cmpxchg2c}
+\input{insn-x86-64/lea}
 \input{insn-x86-64/lods}
 \input{insn-x86-64/mov}
 \input{insn-x86-64/movnti}

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -83,6 +83,8 @@ Manual.  Many of the instruction descriptions in this section reuse
 language from Intel's manual to highlight the similarity in semantics
 between the base instructions and their CHERI extensions.
 
+\input{insn-x86-64/mov}
+
 \clearpage
 \section{CHERI-x86-64 Instructions}
 
@@ -91,6 +93,8 @@ capabilities.  The opcode assignments in this section are tentative
 and subject to change.  Single byte opcodes have been used for
 instructions which we believe may either be used frequently or in
 frequently-accessed code paths.
+
+\input{insn-x86-64/movcap}
 
 \clearpage
 \section{Summary of New Opcodes}
@@ -102,5 +106,9 @@ available in capability mode.
 \noindent
 \begin{tabular}{| l | l |} \hline
   \textbf{Opcode} & \textbf{Instruction}\\
+  \hline
+  0F 24 \emph{/r} & \insnxesref[movcap]{MOV} \emph{rc,} CFS/CGS/DDC\\
+  \hline
+  0F 25 \emph{/r} & \insnxesref[movcap]{MOV} CFS/CGS/DDC\emph{, rc}\\
   \hline
 \end{tabular}

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -101,6 +101,7 @@ and subject to change.  Single byte opcodes have been used for
 instructions which we believe may either be used frequently or in
 frequently-accessed code paths.
 
+\input{insn-x86-64/cinvoke}
 \input{insn-x86-64/movcap}
 \input{insn-x86-64/scaddr}
 \input{insn-x86-64/scbnd}
@@ -126,6 +127,8 @@ available in capability mode.
   37 /0 \emph{id} & \insnxesref{SCBND} \emph{r/mc, imm32}\\
   \hline
   37 /1 \emph{id} & \insnxesref{SCBNDE} \emph{r/mc, imm32}\\
+  \hline
+  EA \emph{/r} & \insnxesref{CINVOKE} \emph{rc, r/mc}\\
   \hline
   0F 24 \emph{/r} & \insnxesref[movcap]{MOV} \emph{rc,} CFS/CGS/DDC\\
   \hline

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -93,10 +93,12 @@ between the base instructions and their CHERI extensions.
 
 \input{insn-x86-64/add}
 \input{insn-x86-64/and}
+\input{insn-x86-64/call}
 \input{insn-x86-64/cmov}
 \input{insn-x86-64/cmp}
 \input{insn-x86-64/cmpxchg}
 \input{insn-x86-64/cmpxchg2c}
+\input{insn-x86-64/jmp}
 \input{insn-x86-64/lea}
 \input{insn-x86-64/lods}
 \input{insn-x86-64/mov}
@@ -105,6 +107,7 @@ between the base instructions and their CHERI extensions.
 \input{insn-x86-64/or}
 \input{insn-x86-64/pop}
 \input{insn-x86-64/push}
+\input{insn-x86-64/ret}
 \input{insn-x86-64/stos}
 \input{insn-x86-64/sub}
 \input{insn-x86-64/xadd}

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -125,6 +125,8 @@ frequently-accessed code paths.
 
 \input{insn-x86-64/andcperm}
 \input{insn-x86-64/cinvoke}
+\input{insn-x86-64/clctag}
+\input{insn-x86-64/clctags}
 \input{insn-x86-64/cram}
 \input{insn-x86-64/crrl}
 \input{insn-x86-64/gcbase}
@@ -139,6 +141,7 @@ frequently-accessed code paths.
 \input{insn-x86-64/scbnde}
 \input{insn-x86-64/scoff}
 \input{insn-x86-64/seal}
+\input{insn-x86-64/sentry}
 \input{insn-x86-64/unseal}
 
 \clearpage
@@ -151,6 +154,12 @@ available in capability mode.
 \noindent
 \begin{tabular}{| l | l |} \hline
   \textbf{Opcode} & \textbf{Instruction}\\
+  \hline
+  0E /0 & \insnxesref{SENTRY} \emph{r/mc}\\
+  \hline
+  0E /1 & \insnxesref{CLCTAG} \emph{r/mc}\\
+  \hline
+  0E /2 & \insnxesref{CLCTAGS} \emph{m8}\\
   \hline
   16 \emph{/r} & \insnxesref{SCADDR} \emph{r/mc, r64}\\
   \hline

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -84,13 +84,16 @@ language from Intel's manual to highlight the similarity in semantics
 between the base instructions and their CHERI extensions.
 
 \input{insn-x86-64/add}
+\input{insn-x86-64/and}
 \input{insn-x86-64/cmov}
 \input{insn-x86-64/lods}
 \input{insn-x86-64/mov}
 \input{insn-x86-64/movnti}
 \input{insn-x86-64/movs}
+\input{insn-x86-64/or}
 \input{insn-x86-64/stos}
 \input{insn-x86-64/sub}
+\input{insn-x86-64/xor}
 
 \clearpage
 \section{CHERI-x86-64 Instructions}

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -83,12 +83,14 @@ Manual.  Many of the instruction descriptions in this section reuse
 language from Intel's manual to highlight the similarity in semantics
 between the base instructions and their CHERI extensions.
 
+\input{insn-x86-64/add}
 \input{insn-x86-64/cmov}
 \input{insn-x86-64/lods}
 \input{insn-x86-64/mov}
 \input{insn-x86-64/movnti}
 \input{insn-x86-64/movs}
 \input{insn-x86-64/stos}
+\input{insn-x86-64/sub}
 
 \clearpage
 \section{CHERI-x86-64 Instructions}

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -1,0 +1,106 @@
+\chapter{The CHERI-x86-64 Instruction-Set Reference}
+\label{chap:isaref-x86-64}
+
+\newcolumntype{Y}{>{\centering\arraybackslash}X}
+\newcolumntype{Z}{>{\raggedright\arraybackslash}X}
+
+\newenvironment{x86opcodetable}{%
+  \tabularx{\textwidth}{| l | l | p{2.0em} | p{2.5em} | p{2.5em} | Z |} \hline
+    \textbf{Opcode} & \textbf{Instruction} & \textbf{Op/ En} &
+    \textbf{Cap Mode} & \textbf{64-bit Mode} & \textbf{Description}\\
+    \hline
+}{%
+  \endtabularx
+}
+
+\newcommand{\xopcode}[6]{%
+  #1 & #2 & #3 & #4 & #5 & #6\\
+  \hline
+}
+
+\newenvironment{x86opentable}{%
+  \bigskip
+  \noindent
+  \tabularx{\textwidth}{| c | Y | Y | Y | Y |}
+    \multicolumn{5}{c}{\bfseries Instruction Operand Encoding}\\
+    \hline
+    Op/En & Operand 1 & Operand 2 & Operand 3 & Operand 4\\
+    \hline
+}{%
+  \endtabularx
+}
+
+\newcommand{\xopen}[5]{%
+  #1 & #2 & #3 & #4 & #5\\
+  \hline
+}
+
+In this chapter, we specify new CHERI instructions as well as
+extensions to existing instructions to support capability-sized
+operands.  Instructions are described using similar syntax to Volume 2
+of Intel's Software Developer's Manual~\cite{intel-sdm-vol2} with a
+few extensions.
+
+An additional symbol is defined to represent object code in the
+``Opcode'' column:
+
+\begin{itemize}
+  \item \textbf{CAP} { }---{ } Indicates the use of the capability
+    operand prefix.
+\end{itemize}
+
+Additional symbols are defined to represent operands in the
+``Instruction'' column:
+
+\begin{itemize}
+  \item \textbf{rc} { }---{ } One of the general-purpose capability
+    registers: \CAX{}, \CBX{}, \CCX{}, \CDX{}, \CDI{}, \CSI{}, \CBP{},
+    \CSP{}, \creg{8}-\creg{15}.
+
+  \item \textbf{r/mc} { }---{ } A capability operand that is either
+    the contents of one of the capability registers for \textbf{rc} or
+    a capability in memory.
+\end{itemize}
+
+In addition, all of these instructions are either invalid or not
+encodable in Compatibility/Legacy mode, so that column is omitted from
+opcode tables.  However, a new column is added to describe capability
+mode support using one of the following annotations:
+
+\begin{itemize}
+  \item \textbf{V} { }---{ } Supported.
+  \item \textbf{I} { }---{ } Not supported.
+\end{itemize}
+
+\clearpage
+\section{Extensions to x86-64 Instructions}
+
+This section contains extensions to existing instructions to support
+capability operands.  For each of these instructions, the instruction
+description should be treated as an extension to the description of
+the existing instruction in Volume 2 of Intel's Software Developer's
+Manual.  Many of the instruction descriptions in this section reuse
+language from Intel's manual to highlight the similarity in semantics
+between the base instructions and their CHERI extensions.
+
+\clearpage
+\section{CHERI-x86-64 Instructions}
+
+This section contains new instructions added to support operations on
+capabilities.  The opcode assignments in this section are tentative
+and subject to change.  Single byte opcodes have been used for
+instructions which we believe may either be used frequently or in
+frequently-accessed code paths.
+
+\clearpage
+\section{Summary of New Opcodes}
+
+The following new opcodes are added in 64-bit mode and are also
+available in capability mode.
+
+\bigskip
+\noindent
+\begin{tabular}{| l | l |} \hline
+  \textbf{Opcode} & \textbf{Instruction}\\
+  \hline
+\end{tabular}

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -124,11 +124,14 @@ instructions which we believe may either be used frequently or in
 frequently-accessed code paths.
 
 \input{insn-x86-64/andcperm}
+\input{insn-x86-64/buildcap}
 \input{insn-x86-64/cinvoke}
 \input{insn-x86-64/clctag}
 \input{insn-x86-64/clctags}
+\input{insn-x86-64/cpytype}
 \input{insn-x86-64/cram}
 \input{insn-x86-64/crrl}
+\input{insn-x86-64/cseal}
 \input{insn-x86-64/gcbase}
 \input{insn-x86-64/gclen}
 \input{insn-x86-64/gcoff}
@@ -186,6 +189,12 @@ available in capability mode.
   F2 0F 0C \emph{/r} & \insnxesref{SEAL} \emph{r/mc, rc}\\
   \hline
   F3 0F 0C \emph{/r} & \insnxesref{UNSEAL} \emph{r/mc, rc}\\
+  \hline
+  VEX.LZ.0F.W0 0E \emph{/r} & \insnxesref{BUILDCAP} \emph{rca, r/mc, rcb}\\
+  \hline
+  VEX.LZ.66.0F.W0 0E \emph{/r} & \insnxesref{CPYTYPE} \emph{rca, r/mc, rcb}\\
+  \hline
+  VEX.LZ.F2.0F.W0 0E \emph{/r} & \insnxesref{CSEAL} \emph{rca, r/mc, rcb}\\
   \hline
   0F 24 \emph{/r} & \insnxesref[movcap]{MOV} \emph{rc,} CFS/CGS/DDC\\
   \hline

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -103,6 +103,8 @@ frequently-accessed code paths.
 
 \input{insn-x86-64/movcap}
 \input{insn-x86-64/scaddr}
+\input{insn-x86-64/scbnd}
+\input{insn-x86-64/scbnde}
 
 \clearpage
 \section{Summary of New Opcodes}
@@ -116,6 +118,14 @@ available in capability mode.
   \textbf{Opcode} & \textbf{Instruction}\\
   \hline
   16 \emph{/r} & \insnxesref{SCADDR} \emph{r/mc, r64}\\
+  \hline
+  17 \emph{/r} & \insnxesref{SCBND} \emph{r/mc, r64}\\
+  \hline
+  27 \emph{/r} & \insnxesref{SCBNDE} \emph{r/mc, r64}\\
+  \hline
+  37 /0 \emph{id} & \insnxesref{SCBND} \emph{r/mc, imm32}\\
+  \hline
+  37 /1 \emph{id} & \insnxesref{SCBNDE} \emph{r/mc, imm32}\\
   \hline
   0F 24 \emph{/r} & \insnxesref[movcap]{MOV} \emph{rc,} CFS/CGS/DDC\\
   \hline

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -77,6 +77,7 @@ mode support using one of the following annotations:
 \begin{itemize}
   \item \textbf{V} { }---{ } Supported.
   \item \textbf{I} { }---{ } Not supported.
+  \item \textbf{N. E.} { }---{ } Not encodable in capability mode.
 \end{itemize}
 
 \clearpage
@@ -102,6 +103,8 @@ between the base instructions and their CHERI extensions.
 \input{insn-x86-64/movnti}
 \input{insn-x86-64/movs}
 \input{insn-x86-64/or}
+\input{insn-x86-64/pop}
+\input{insn-x86-64/push}
 \input{insn-x86-64/stos}
 \input{insn-x86-64/sub}
 \input{insn-x86-64/xadd}

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -83,8 +83,11 @@ Manual.  Many of the instruction descriptions in this section reuse
 language from Intel's manual to highlight the similarity in semantics
 between the base instructions and their CHERI extensions.
 
+\input{insn-x86-64/lods}
 \input{insn-x86-64/mov}
 \input{insn-x86-64/movnti}
+\input{insn-x86-64/movs}
+\input{insn-x86-64/stos}
 
 \clearpage
 \section{CHERI-x86-64 Instructions}

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -102,6 +102,8 @@ instructions which we believe may either be used frequently or in
 frequently-accessed code paths.
 
 \input{insn-x86-64/cinvoke}
+\input{insn-x86-64/cram}
+\input{insn-x86-64/crrl}
 \input{insn-x86-64/movcap}
 \input{insn-x86-64/scaddr}
 \input{insn-x86-64/scbnd}
@@ -121,6 +123,10 @@ available in capability mode.
   16 \emph{/r} & \insnxesref{SCADDR} \emph{r/mc, r64}\\
   \hline
   17 \emph{/r} & \insnxesref{SCBND} \emph{r/mc, r64}\\
+  \hline
+  1E \emph{/r} & \insnxesref{CRRL} \emph{r64, r/m64}\\
+  \hline
+  1F \emph{/r} & \insnxesref{CRAM} \emph{r64, r/m64}\\
   \hline
   27 \emph{/r} & \insnxesref{SCBNDE} \emph{r/mc, r64}\\
   \hline

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -102,6 +102,7 @@ instructions which we believe may either be used frequently or in
 frequently-accessed code paths.
 
 \input{insn-x86-64/movcap}
+\input{insn-x86-64/scaddr}
 
 \clearpage
 \section{Summary of New Opcodes}
@@ -113,6 +114,8 @@ available in capability mode.
 \noindent
 \begin{tabular}{| l | l |} \hline
   \textbf{Opcode} & \textbf{Instruction}\\
+  \hline
+  16 \emph{/r} & \insnxesref{SCADDR} \emph{r/mc, r64}\\
   \hline
   0F 24 \emph{/r} & \insnxesref[movcap]{MOV} \emph{rc,} CFS/CGS/DDC\\
   \hline

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -84,6 +84,7 @@ language from Intel's manual to highlight the similarity in semantics
 between the base instructions and their CHERI extensions.
 
 \input{insn-x86-64/mov}
+\input{insn-x86-64/movnti}
 
 \clearpage
 \section{CHERI-x86-64 Instructions}

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -123,6 +123,7 @@ and subject to change.  Single byte opcodes have been used for
 instructions which we believe may either be used frequently or in
 frequently-accessed code paths.
 
+\input{insn-x86-64/andcperm}
 \input{insn-x86-64/cinvoke}
 \input{insn-x86-64/cram}
 \input{insn-x86-64/crrl}
@@ -136,6 +137,9 @@ frequently-accessed code paths.
 \input{insn-x86-64/scaddr}
 \input{insn-x86-64/scbnd}
 \input{insn-x86-64/scbnde}
+\input{insn-x86-64/scoff}
+\input{insn-x86-64/seal}
+\input{insn-x86-64/unseal}
 
 \clearpage
 \section{Summary of New Opcodes}
@@ -162,7 +166,17 @@ available in capability mode.
   \hline
   37 /1 \emph{id} & \insnxesref{SCBNDE} \emph{r/mc, imm32}\\
   \hline
+  37 /2 \emph{id} & \insnxesref{ANDCPERM} \emph{r/mc, imm32}\\
+  \hline
   EA \emph{/r} & \insnxesref{CINVOKE} \emph{rc, r/mc}\\
+  \hline
+  NP 0F 0C \emph{/r} & \insnxesref{ANDCPERM} \emph{r/mc, r64}\\
+  \hline
+  66 0F 0C \emph{/r} & \insnxesref{SCOFF} \emph{r/mc, r64}\\
+  \hline
+  F2 0F 0C \emph{/r} & \insnxesref{SEAL} \emph{r/mc, rc}\\
+  \hline
+  F3 0F 0C \emph{/r} & \insnxesref{UNSEAL} \emph{r/mc, rc}\\
   \hline
   0F 24 \emph{/r} & \insnxesref[movcap]{MOV} \emph{rc,} CFS/CGS/DDC\\
   \hline

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -47,6 +47,10 @@ An additional symbol is defined to represent object code in the
 \begin{itemize}
   \item \textbf{CAP} { }---{ } Indicates the use of the capability
     operand prefix.
+
+  \item \textbf{+rc} { }---{ } Indicates the lower 3 bits of the
+    opcode byte is used to encode the register operand without a
+    modR/M byte.
 \end{itemize}
 
 Additional symbols are defined to represent operands in the
@@ -60,6 +64,9 @@ Additional symbols are defined to represent operands in the
   \item \textbf{r/mc} { }---{ } A capability operand that is either
     the contents of one of the capability registers for \textbf{rc} or
     a capability in memory.
+
+  \item \textbf{m2c} { }---{ } A pair of adjacent capabilities in
+    memory.
 \end{itemize}
 
 In addition, all of these instructions are either invalid or not
@@ -87,6 +94,8 @@ between the base instructions and their CHERI extensions.
 \input{insn-x86-64/and}
 \input{insn-x86-64/cmov}
 \input{insn-x86-64/cmp}
+\input{insn-x86-64/cmpxchg}
+\input{insn-x86-64/cmpxchg2c}
 \input{insn-x86-64/lods}
 \input{insn-x86-64/mov}
 \input{insn-x86-64/movnti}
@@ -94,6 +103,8 @@ between the base instructions and their CHERI extensions.
 \input{insn-x86-64/or}
 \input{insn-x86-64/stos}
 \input{insn-x86-64/sub}
+\input{insn-x86-64/xadd}
+\input{insn-x86-64/xchg}
 \input{insn-x86-64/xor}
 
 \clearpage

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -83,6 +83,7 @@ Manual.  Many of the instruction descriptions in this section reuse
 language from Intel's manual to highlight the similarity in semantics
 between the base instructions and their CHERI extensions.
 
+\input{insn-x86-64/cmov}
 \input{insn-x86-64/lods}
 \input{insn-x86-64/mov}
 \input{insn-x86-64/movnti}

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -216,3 +216,50 @@ available in capability mode.
   66 0F 7B \emph{/r} & \insnxesref{GCOFF} \emph{r64, r/mc}\\
   \hline
 \end{tabular}
+
+\clearpage
+\section{Instructions Deprecated in Capability Mode}
+
+The following instructions are valid in 64-bit mode but invalid in
+capability mode.  For conciseness, the placeholder \texttt{XX} in the
+table below indicates any valid size for the instruction (i.e. 8, 16, 32,
+or 64).
+
+\bigskip
+\noindent
+\begin{tabularx}{\textwidth}{| l | l | Z |} \hline
+  \textbf{Opcode} & \textbf{Instruction} &
+  \textbf{Description}\\
+  \hline
+  A0 & MOV AL,\emph{moffs8} & Move byte at (\emph{offset}) to AL.\\
+  \hline
+  A1 & MOV [ER]AX,\emph{moffsxx} & Move value at (\emph{offset}) to [ER]AX.\\
+  \hline
+  A2 & MOV \emph{moffs8},AL & Move AL to  (\emph{offset}).\\
+  \hline
+  A3 & MOV \emph{moffs8},[ER]AX & Move [ER]AX to  (\emph{offset}).\\
+  \hline
+  0F 02 \emph{/r} & LAR \emph{rxx,rxx/m16} &
+  Load access rights.\\
+  \hline
+  0F 03 \emph{/r} & LSL \emph{rxx,rxx/m16} &
+  Load segment limit.\\
+  \hline
+  0F A0 & PUSH FS & Push FS.\\
+  \hline
+  0F A1 & POP FS & Pop FS.\\
+  \hline
+  0F A8 & PUSH GS & Push GS.\\
+  \hline
+  0F A9 & POP GS & Pop GS.\\
+  \hline
+  0F B2 \emph{/r} & LSS \emph{rxx,m16:xx} &
+  Load SS:\emph{rxx} with far pointer.\\
+  \hline
+  0F B4 \emph{/r} & LFS \emph{rxx,m16:xx} &
+  Load FS:\emph{rxx} with far pointer.\\
+  \hline
+  0F B5 \emph{/r} & LGS \emph{rxx,m16:xx} &
+  Load GS:\emph{rxx} with far pointer.\\
+  \hline
+\end{tabularx}

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -138,6 +138,7 @@ frequently-accessed code paths.
 \input{insn-x86-64/gcperm}
 \input{insn-x86-64/gctag}
 \input{insn-x86-64/gctype}
+\input{insn-x86-64/lctags}
 \input{insn-x86-64/movcap}
 \input{insn-x86-64/scaddr}
 \input{insn-x86-64/scbnd}
@@ -173,6 +174,8 @@ available in capability mode.
   1F \emph{/r} & \insnxesref{CRAM} \emph{r64, r/m64}\\
   \hline
   27 \emph{/r} & \insnxesref{SCBNDE} \emph{r/mc, r64}\\
+  \hline
+  2F \emph{/r} & \insnxesref{LCTAGS} \emph{r64, m8}\\
   \hline
   37 /0 \emph{id} & \insnxesref{SCBND} \emph{r/mc, imm32}\\
   \hline

--- a/chap-research.tex
+++ b/chap-research.tex
@@ -908,7 +908,7 @@ This report describes a software-facing protection model
 specific mapping into the 32-bit and 64-bit RISC-V ISA for the purposes of experimentation
 and evaluation (Chapters~\ref{chap:architecture}, ~\ref{chap:cheri-riscv}
 and~\ref{chap:isaref-riscv}), and architectural sketches for potential integration
-into other ISAs (Chapter~\ref{chap:cheri-x86-64} on CHERI-x86-64 and Arm
+into other ISAs (Chapters~\ref{chap:cheri-x86-64} and~\ref{chap:isaref-x86-64} on CHERI-x86-64 and Arm
 Morello~\cite{arm-morello}).
 However, we have taken a ``ground-up'' approach utilizing hardware-software
 co-design to ensure that concrete mapping exist that

--- a/cheri-architecture.tex
+++ b/cheri-architecture.tex
@@ -137,6 +137,7 @@
 \input{chap-cheri-x86-64}
 \input{chap-sail}
 \input{chap-isaref-riscv}
+\input{chap-isaref-x86-64}
 \input{chap-rationale}
 \input{chap-assurance}
 \input{chap-microarchitecture}

--- a/insn-x86-64/add.tex
+++ b/insn-x86-64/add.tex
@@ -1,0 +1,50 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{ADD - Add}
+\insnxeslabel{add}
+\subsection*{ADD - Add}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + 05 \emph{id}}{ADD CAX\emph{, imm32}}
+  {I}{Valid}{Valid}
+  {Add \emph{imm32 sign-extended to 64-bits} to the address field of
+    CAX.}
+  \xopcode{CAP + 81 /0 \emph{id}}{ADD \emph{r/mc, imm32}}
+  {MI}{Valid}{Valid}
+  {Add \emph{imm32 sign-extended to 64-bits} to the address field of
+    \emph{r/mc}.}
+  \xopcode{CAP + 83 /0 \emph{ib}}{ADD \emph{r/mc, imm8}}
+  {MI}{Valid}{Valid}
+  {Add \emph{sign}-extended \emph{imm8} to the address field of
+    \emph{r/mc}.}
+  \xopcode{CAP + 01 \emph{/r}}{ADD \emph{r/mc, r64}}
+  {MR}{Valid}{Valid}
+  {Add \emph{r64} to the address field of \emph{r/mc}.}
+  \xopcode{CAP + 03 \emph{/r}}{ADD \emph{rc, r/m64}}
+  {RM}{Valid}{Valid}
+  {Add \emph{r/m64} to the address field of \emph{rc}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:Reg (r,w)}{ModRM:r/m (r)}{NA}{NA}
+  \xopen{MR}{ModRM:r/m (r,w)}{ModRM:reg (r)}{NA}{NA}
+  \xopen{MI}{ModRM:r/m (r,w)}{imm8/32}{NA}{NA}
+  \xopen{I}{CAX}{imm32}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Adds the source operand to the \textbf{address} field of the
+destination operand and then stores the result in the destination
+operand. The destination operand can be a register or a memory
+location. The source operand can be an immediate, a register, or a
+memory location.
+
+If the new value of the \textbf{address} field makes the resulting
+capability unrepresentable, the \textbf{tag} field in the resulting
+capability is cleared.
+
+\subsubsection*{Flags Affected}
+
+The OF, SF, ZF, AF, CF, and PF flags are set according to the value of
+the resulting \textbf{address} field.

--- a/insn-x86-64/and.tex
+++ b/insn-x86-64/and.tex
@@ -1,0 +1,51 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{AND - Logical AND}
+\insnxeslabel{and}
+\subsection*{AND - Logical AND}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + 25 \emph{id}}{AND CAX\emph{, imm32}}
+  {I}{Valid}{Valid}
+  {Bitwise AND of \emph{imm32 sign-extended to 64-bits} with the
+    address field of CAX.}
+  \xopcode{CAP + 81 /4 \emph{id}}{AND \emph{r/mc, imm32}}
+  {MI}{Valid}{Valid}
+  {Bitwise AND of \emph{imm32 sign-extended to 64-bits} with the
+    address field of \emph{r/mc}.}
+  \xopcode{CAP + 83 /4 \emph{ib}}{AND \emph{r/mc, imm8}}
+  {MI}{Valid}{Valid}
+  {Bitwise AND of \emph{sign}-extended \emph{imm8} with the address
+    field of \emph{r/mc}.}
+  \xopcode{CAP + 21 \emph{/r}}{AND \emph{r/mc, r64}}
+  {MR}{Valid}{Valid}
+  {Bitwise AND of \emph{r64} with the address field of \emph{r/mc}.}
+  \xopcode{CAP + 23 \emph{/r}}{AND \emph{rc, r/m64}}
+  {RM}{Valid}{Valid}
+  {Bitwise AND of \emph{r/m64} with the address field of \emph{rc}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:Reg (r,w)}{ModRM:r/m (r)}{NA}{NA}
+  \xopen{MR}{ModRM:r/m (r,w)}{ModRM:reg (r)}{NA}{NA}
+  \xopen{MI}{ModRM:r/m (r,w)}{imm8/32}{NA}{NA}
+  \xopen{I}{CAX}{imm32}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Derives a new capability from the destination operand whose
+\textbf{address} field is set to the bitwise AND of the source operand
+and the \textbf{address} field of the destination operand and then
+stores the result in the destination operand. The destination operand
+can be a register or a memory location. The source operand can be an
+immediate, a register, or a memory location.
+
+If the new value of the \textbf{address} field makes the resulting
+capability unrepresentable, the \textbf{tag} field in the resulting
+capability is cleared.
+
+\subsubsection*{Flags Affected}
+
+The OF, SF, ZF, AF, CF, and PF flags are set according to the value of
+the resulting \textbf{address} field.

--- a/insn-x86-64/andcperm.tex
+++ b/insn-x86-64/andcperm.tex
@@ -1,0 +1,32 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{ANDCPERM - Mask Capability Permissions}
+\insnxeslabel{andcperm}
+\subsection*{ANDCPERM - Mask Capability Permissions}
+
+\begin{x86opcodetable}
+  \xopcode{NP 0F 0C \emph{/r}}{ANDCPERM \emph{r/mc, r64}}
+  {MR}{Valid}{Valid}
+  {Mask permissions of \emph{r/mc} by \emph{r64}.}
+  \xopcode{37 /2 \emph{id}}{ANDCPERM \emph{r/mc, imm32}}
+  {MI}{Valid}{Valid}
+  {Mask permissions of \emph{r/mc} by sign-extended \emph{imm32}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{MR}{ModRM:r/m (r, w)}{ModRM:reg (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Derives a new capability from the destination operand with the
+\textbf{perms} and \textbf{uperms} field bitwise ANDed with the source
+operand and stores the result in the destination operand.  The
+destination operand can be a register or memory location; the source
+operand can be a register or immediate.  If the destination operand is
+sealed and tagged, set the destination operand to its original value
+with the \textbf{tag} field cleared.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/buildcap.tex
+++ b/insn-x86-64/buildcap.tex
@@ -1,0 +1,35 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{BUILDCAP - Construct Capability}
+\insnxeslabel{buildcap}
+\subsection*{BUILDCAP - Construct Capability}
+
+\begin{x86opcodetable}
+  \xopcode{VEX.LZ.0F.W0 0E \emph{/r}}{BUILDCAP \emph{rca, r/mc, rcb}}
+  {RMV}{Valid}{Valid}
+  {Construct capability from \emph{r/mc} and \emph{rcb} and store in
+    \emph{rca}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RMV}{ModRM:reg (w)}{ModRM:r/m (r)}{VEX.vvvv (r)}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Constructs a new capability equal to the second operand with the
+\textbf{base}, \textbf{length}, \textbf{address}, \textbf{perms}, and
+\textbf{uperms} fields replaced with the corresponding fields from the
+third operand and stores the result in the first (destination) operand.
+If the third operand is a sentry then the result is also sealed as a
+sentry.  If the resulting capability is not a subset of the second
+operand in bounds or permissions, or is not a legally-derivable
+capability, or if the second operand did not have its \textbf{tag}
+field set, or if the second operand was sealed as a non-sentry, the
+resulting capability is set to the third operand with the \textbf{tag}
+field cleared.
+
+\subsubsection*{Flags Affected}
+
+ZF is set to the \textbf{tag} field of the resulting capability.  The
+CF, PF, AF, and OF flags are undefined.

--- a/insn-x86-64/call.tex
+++ b/insn-x86-64/call.tex
@@ -1,0 +1,67 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{CALL - Call Procedure}
+\insnxeslabel{call}
+\subsection*{CALL - Call Procedure}
+
+\begin{x86opcodetable}
+  \xopcode{E8 \emph{cw}}{CALL \emph{rel16}}
+  {D}{Invalid}{N.S.}
+  {Call near, relative displacement.}
+  \xopcode{E8 \emph{cd}}{CALL \emph{rel32}}
+  {D}{Valid}{Valid}
+  {Call near, relative displacement, 32-bit displacement sign-extended
+    to 64-bits.}
+  \xopcode{FF /2}{CALL \emph{r/m16}}
+  {M}{N.E.}{N.E.}
+  {Call near, absolute indirect, address given in \emph{r/m16}.}
+  \xopcode{FF /2}{CALL \emph{r/m32}}
+  {M}{N.E.}{N.E.}
+  {Call near, absolute indirect, address given in \emph{r/m32}.}
+  \xopcode{FF /2}{CALL \emph{r/m64}}
+  {M}{Invalid}{Valid}
+  {Call near, absolute indirect, address given in \emph{r/m64}.}
+  \xopcode{FF /2}{CALL \emph{r/mc}}
+  {M}{Valid}{Valid}
+  {Call near, absolute indirect, address given in \emph{r/mc}.}
+  \xopcode{9A \emph{cd}}{CALL \emph{ptr16:16}}
+  {D}{N.E.}{N.E.}
+  {Call far, absolute, address in operand.}
+  \xopcode{9A \emph{cp}}{CALL \emph{ptr16:32}}
+  {D}{N.E.}{N.E.}
+  {Call far, absolute, address in operand.}
+  \xopcode{FF /3}{CALL \emph{m16:16}}
+  {M}{Valid}{Valid}
+  {Call far, absolute indirect, address given in \emph{m16:16}.}
+  \xopcode{FF /3}{CALL \emph{m16:32}}
+  {M}{Valid}{Valid}
+  {Call far, absolute indirect, address given in \emph{m16:32}.}
+  \xopcode{REX.W FF /3}{CALL \emph{m16:64}}
+  {M}{Valid}{Valid}
+  {Call far, absolute indirect, address given in \emph{m16:64}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{D}{Offset}{NA}{NA}{NA}
+  \xopen{M}{ModRM:r/m (r)}{NA}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Saves return address on the stack and branches to the location
+specified by the first operand.  In 64-bit mode the \insnnoref{CAP}
+prefix can be used with opcode \texttt{FF /2} to select the capability
+operand size instead of 64-bit.  In capability mode, near calls always
+use the capability operand size.
+
+Relative calls always apply the relative displacement to the address
+of the next instruction to compute a new value of the \textbf{address}
+field of \CIP{}.
+
+Near calls which use a capability operand size always push \CIP{} onto
+the current stack before executing the first instruction at the target
+rather than pushing the value of \RIP{}.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/cinvoke.tex
+++ b/insn-x86-64/cinvoke.tex
@@ -1,0 +1,32 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{CINVOKE - Invoke Sealed Capability Pair}
+\insnxeslabel{cinvoke}
+\subsection*{CINVOKE - Invoke Sealed Capability Pair}
+
+\begin{x86opcodetable}
+  \xopcode{EA \emph{/r}}{CINVOKE \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Set CAX to \emph{r/mc} and jump to \emph{rc}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:reg (r)}{ModRM:r/m (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Jumps to a pair of sealed capabilities.  The first source operand can
+be a register; the second source operand can be a register or memory
+location.
+
+If both operands are sealed with the same \textbf{otype}, sets \CIP{}
+to the unsealed first operand and sets \CAX{} to the unsealed second
+operand.  Note that this control transfer is a jump and does not push
+any values onto the stack.  If this instruction fails, it raises a
+Capability Violation Fault (see
+Section~\ref{sec:x86:capability-fault}).
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/clctag.tex
+++ b/insn-x86-64/clctag.tex
@@ -1,0 +1,24 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{CLCTAG - Clear Capability Tag}
+\insnxeslabel{clctag}
+\subsection*{CLCTAG - Clear Capability Tag}
+
+\begin{x86opcodetable}
+  \xopcode{0E /1}{CLCTAG \emph{r/mc}}
+  {M}{Valid}{Valid}
+  {Clear tag of \emph{r/mc}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{M}{ModRM:r/m (r, w)}{NA}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Clears the \textbf{tag} field of the destination operand.  The
+destination operand can be a register or memory location.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/clctags.tex
+++ b/insn-x86-64/clctags.tex
@@ -1,0 +1,30 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{CLCTAGS - Clear Capability Tags}
+\insnxeslabel{clctags}
+\subsection*{CLCTAGS - Clear Capability Tags}
+
+\begin{x86opcodetable}
+  \xopcode{0E /2}{CLCTAGS \emph{m8}}
+  {M}{Valid}{Valid}
+  {Clear capability tags of \emph{m8}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{M}{ModRM:r/m (w)}{NA}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Clears the capability tags for a stride of capabilities in memory
+starting at the destination operand.  The authorizing capability for
+the destination operand must include \cappermS{} and authorize access
+to the entire stride of capabilities.  The address of the destination
+operand must also be aligned to a stride of capabilities.
+
+If this instruction fails, it raises either a Capability Violation
+Fault (see Section~\ref{sec:x86:capability-fault}) or a Page Fault.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/cmov.tex
+++ b/insn-x86-64/cmov.tex
@@ -1,0 +1,71 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{CMOVcc - Conditional Move}
+\insnxeslabel{cmov}
+\subsection*{CMOV\emph{cc} - Conditional Move}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + 0F 40 \emph{/r}}{CMOVO \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if overflow (OF=1).}
+  \xopcode{CAP + 0F 41 \emph{/r}}{CMOVNO \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if not overflow (OF=0).}
+  \xopcode{CAP + 0F 42 \emph{/r}}{CMOVC \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if carry (CF=1).}
+  \xopcode{CAP + 0F 43 \emph{/r}}{CMOVNC \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if not carry (CF=0).}
+  \xopcode{CAP + 0F 44 \emph{/r}}{CMOVZ \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if zero (ZF=1).}
+  \xopcode{CAP + 0F 45 \emph{/r}}{CMOVNZ \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if not zero (ZF=0).}
+  \xopcode{CAP + 0F 46 \emph{/r}}{CMOVBE \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if below or equal (CF=1 or ZF=1).}
+  \xopcode{CAP + 0F 47 \emph{/r}}{CMOVA \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if above (CF=0 and ZF=0).}
+  \xopcode{CAP + 0F 48 \emph{/r}}{CMOVS \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if sign (SF=1).}
+  \xopcode{CAP + 0F 49 \emph{/r}}{CMOVNS \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if not sign (SF=0).}
+  \xopcode{CAP + 0F 4A \emph{/r}}{CMOVP \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if parity (PF=1).}
+  \xopcode{CAP + 0F 4B \emph{/r}}{CMOVNP \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if no parity (PF=0).}
+  \xopcode{CAP + 0F 4C \emph{/r}}{CMOVL \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if less (SF$\neq{}$OF).}
+  \xopcode{CAP + 0F 4D \emph{/r}}{CMOVGE \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if greater or equal (SF=OF).}
+  \xopcode{CAP + 0F 4E \emph{/r}}{CMOVLE \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if less or equal (ZF=1 or SF$\neq{}$OF).}
+  \xopcode{CAP + 0F 4F \emph{/r}}{CMOVG \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move if greater (ZF=0 and SF=OF).}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:Reg (w)}{ModRM:r/m (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Copies the source operand to the destination operand if one or more
+status flags in the \RFLAGS{} register are in the required state. The
+destination operand is a register.  The source operand can be a
+register or memory location.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/cmp.tex
+++ b/insn-x86-64/cmp.tex
@@ -1,0 +1,32 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{CMP - Compare Two Operands}
+\insnxeslabel{cmp}
+\subsection*{CMP - Compare Two Operands}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + 39 \emph{/r}}{CMP \emph{r/mc, rc}}
+  {MR}{Valid}{Valid}
+  {Compare \emph{rc} with \emph{r/mc}.}
+  \xopcode{CAP + 3B \emph{/r}}{CMP \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Compare \emph{r/mc} with \emph{rc}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:Reg (r)}{ModRM:r/m (r)}{NA}{NA}
+  \xopen{MR}{ModRM:r/m (r)}{ModRM:reg (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Compares the first source operand with the scond source operand and
+sets status flags in \RFLAGS{}.  Sets ZF to 1 if the two operands are
+equal and 0 otherwise.  Sets SF to 1 if the \textbf{tag} fields of the
+two operands are equal and the bounds and permissions of the second
+operand are a subset of the first operand.
+
+\subsubsection*{Flags Affected}
+
+The ZF and SF flags are set as described above.  The OF, SF, AF, CF,
+and PF flags are undefined.

--- a/insn-x86-64/cmpxchg.tex
+++ b/insn-x86-64/cmpxchg.tex
@@ -1,0 +1,30 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{CMPXCHG - Compare and Exchange}
+\insnxeslabel{cmpxchg}
+\subsection*{CMPXCHG - Compare and Exchange}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + 0F B1 \emph{/r}}{CMPXCHG \emph{r/mc, rc}}
+  {MR}{Valid}{Valid}
+  {Compare CAX with \emph{r/mc}. If equal, store \emph{rc} to
+    \emph{r/mc}, else load \emph{r/mc} into CAX.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{MR}{ModRM:r/m (r,w)}{ModRM:reg (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Compares \CAX{} with the destination operand.  If the values are
+equal, stores the source operand in the destination operand.  If the
+values are not equal, loads the destination operand into \CAX{}.
+
+The instruction can be used with a \insnnoref{LOCK} prefix to execute
+atomically.
+
+\subsubsection*{Flags Affected}
+
+The OF, SF, ZF, AF, CF, and PF flags are set according to the value of
+the result of comparing \CAX{} with the destination operand.

--- a/insn-x86-64/cmpxchg2c.tex
+++ b/insn-x86-64/cmpxchg2c.tex
@@ -1,0 +1,33 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{CMPXCHG2C - Compare and Exchange Pair}
+\insnxeslabel{cmpxchg2c}
+\subsection*{CMPXCHG2C - Compare and Exchange Pair}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + 0F C7 /1}{CMPXCHG2C \emph{m2c}}
+  {MR}{Valid}{Valid}
+  {Compare CDX:CAX with \emph{m2c}. If equal, set ZF and CCX:CBX to
+    \emph{m2c}, else load \emph{m2c} into CDX:CAX.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{MR}{ModRM:r/m (r,w)}{ModRM:reg (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Compares the pair of capabilities in \CDX{}:\CAX{} with the
+destination operand.  \CAX{} is compared with the first capability in
+memory, and \CDX{} is compared with the second capability in memory.
+If the capabilities are equal, stores \CCX{}:\CBX{} in the destination
+operand.  If the capabilities are not equal, loads the destination
+operand into \CDX{}:\CAX{}.
+
+The instruction can be used with a \insnnoref{LOCK} prefix to execute
+atomically.
+
+\subsubsection*{Flags Affected}
+
+The ZF flag is set to the result of the comparison (1 if equal).  The
+OF, SF, AF, CF, and PF flags are unaffected.

--- a/insn-x86-64/cpytype.tex
+++ b/insn-x86-64/cpytype.tex
@@ -1,0 +1,30 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{CPYTYPE - Construct Sealing Capability}
+\insnxeslabel{cpytype}
+\subsection*{CPYTYPE - Construct Sealing Capability}
+
+\begin{x86opcodetable}
+  \xopcode{VEX.LZ.66.0F.W0 0E \emph{/r}}{CPYTYPE \emph{rca, r/mc, rcb}}
+  {RMV}{Valid}{Valid}
+  {Construct a sealing capability from \emph{r/mc} and \emph{rcb} and
+    store in \emph{rca}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RMV}{ModRM:reg (w)}{ModRM:r/m (r)}{VEX.vvvv (r)}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Constructs a new capability equal to the second operand with the
+\textbf{address} field set to the \textbf{otype} field of the third
+operand and stores the result in the first (destination) operand.
+If the third operand's \textbf{otype} field is reserved or if the
+second operand was sealed, the \textbf{tag} in the resulting
+capability is cleared.
+
+\subsubsection*{Flags Affected}
+
+ZF is set to the \textbf{tag} field of the resulting capability.  The
+CF, PF, AF, and OF flags are undefined.

--- a/insn-x86-64/cram.tex
+++ b/insn-x86-64/cram.tex
@@ -1,0 +1,27 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{CRAM - Representable Alignment Mask}
+\insnxeslabel{cram}
+\subsection*{CRAM - Representable Alignment Mask}
+
+\begin{x86opcodetable}
+  \xopcode{1F \emph{/r}}{CRAM \emph{r64, r/m64}}
+  {RM}{Valid}{Valid}
+  {Set \emph{r64} to mask sufficient for aligned bounds spanning the
+    length in \emph{r/m64}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:reg (w)}{ModRM:r/m (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Sets the destination operand to a mask that can be used to round
+addresses down to a value that is sufficiently aligned to set exact
+bounds for the nearest representable length of the source operand.
+The source operand can be a register or memory location.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/crrl.tex
+++ b/insn-x86-64/crrl.tex
@@ -1,0 +1,27 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{CRRL - Round Representable Length}
+\insnxeslabel{crrl}
+\subsection*{CRRL - Round Representable Length}
+
+\begin{x86opcodetable}
+  \xopcode{1E \emph{/r}}{CRRL \emph{r64, r/m64}}
+  {RM}{Valid}{Valid}
+  {Set \emph{r64} to minimum representable length greater or equal to
+    \emph{r/m64}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:reg (w)}{ModRM:r/m (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Sets the destination operand to the smallest value greater or equal to
+the source operand that can be used as a length to set exact bounds on
+a capability with a suitably aligned base.  The source operand can be
+a register or memory location.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/cseal.tex
+++ b/insn-x86-64/cseal.tex
@@ -1,0 +1,28 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{CSEAL - Conditional Capability Seal}
+\insnxeslabel{cseal}
+\subsection*{CSEAL - Conditional Capability Seal}
+
+\begin{x86opcodetable}
+  \xopcode{VEX.LZ.F2.0F.W0 0E \emph{/r}}{CSEAL \emph{rca, r/mc, rcb}}
+  {RMV}{Valid}{Valid}
+  {Conditionally seal \emph{r/mc} with type from address field of
+    \emph{rcb} and store in \emph{rca}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RMV}{ModRM:reg (w)}{ModRM:r/m (r)}{VEX.vvvv (r)}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Seals the second operand with the \textbf{otype} equal to the
+\textbf{address} field of the third operand and stores the result in
+the first (destination) operand.  If the sealing operation fails, the
+second operand is copied to the first operand.
+
+\subsubsection*{Flags Affected}
+
+The ZF flag is set to 1 if the sealing operation succeeds; otherwise
+0.  The CF, PF, AF, SF, and OF flags are undefined.

--- a/insn-x86-64/gcbase.tex
+++ b/insn-x86-64/gcbase.tex
@@ -1,0 +1,25 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{GCBASE - Get Capability Base}
+\insnxeslabel{gcbase}
+\subsection*{GCBASE - Get Capability Base}
+
+\begin{x86opcodetable}
+  \xopcode{F2 0F 7A \emph{/r}}{GCBASE \emph{r64, r/mc}}
+  {RM}{Valid}{Valid}
+  {Store the base field of \emph{r/mc} in \emph{r64}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:reg (w)}{ModRM:r/m (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Sets the destination operand to the \textbf{base} field of the source
+operand.  The source operand can be a register or memory location.
+
+\subsubsection*{Flags Affected}
+
+ZF is set to 1 if the result is zero.  The CF, PF, AF, SF, and OF
+flags are undefined.

--- a/insn-x86-64/gclen.tex
+++ b/insn-x86-64/gclen.tex
@@ -1,0 +1,26 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{GCLEN - Get Capability Length}
+\insnxeslabel{gclen}
+\subsection*{GCLEN - Get Capability Length}
+
+\begin{x86opcodetable}
+  \xopcode{F3 0F 7A \emph{/r}}{GCLEN \emph{r64, r/mc}}
+  {RM}{Valid}{Valid}
+  {Store the bounds length of \emph{r/mc} in \emph{r64}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:reg (w)}{ModRM:r/m (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Sets the destination operand to the \textbf{length} field of the
+source operand.  The source operand can be a register or memory
+location.
+
+\subsubsection*{Flags Affected}
+
+ZF is set to 1 if the result is zero.  The CF, PF, AF, SF, and OF
+flags are undefined.

--- a/insn-x86-64/gcoff.tex
+++ b/insn-x86-64/gcoff.tex
@@ -1,0 +1,26 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{GCOFF - Get Capability Offset}
+\insnxeslabel{gcoff}
+\subsection*{GCOFF - Get Capability Offset}
+
+\begin{x86opcodetable}
+  \xopcode{66 0F 7B \emph{/r}}{GCOFF \emph{r64, r/mc}}
+  {RM}{Valid}{Valid}
+  {Store the offset of \emph{r/mc} in \emph{r64}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:reg (w)}{ModRM:r/m (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Sets the destination operand to the \textbf{offset} field of the
+source operand.  The source operand can be a register or memory
+location.
+
+\subsubsection*{Flags Affected}
+
+ZF is set to 1 if the result is zero.  The CF, PF, AF, SF, and OF
+flags are undefined.

--- a/insn-x86-64/gcperm.tex
+++ b/insn-x86-64/gcperm.tex
@@ -1,0 +1,26 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{GCPERM - Get Capability Permissions}
+\insnxeslabel{gcperm}
+\subsection*{GCPERM - Get Capability Permissions}
+
+\begin{x86opcodetable}
+  \xopcode{NP 0F 7A \emph{/r}}{GCPERM \emph{r64, r/mc}}
+  {RM}{Valid}{Valid}
+  {Store the permissions mask of \emph{r/mc} in \emph{r64}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:reg (w)}{ModRM:r/m (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Sets the destination operand to the combined \textbf{perms} and
+\textbf{uperms} fields of the source operand.  The source operand can
+be a register or memory location.
+
+\subsubsection*{Flags Affected}
+
+ZF is set to 1 if the result is zero.  The CF, PF, AF, SF, and OF
+flags are undefined.

--- a/insn-x86-64/gctag.tex
+++ b/insn-x86-64/gctag.tex
@@ -1,0 +1,25 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{GCTAG - Get Capability Tag}
+\insnxeslabel{gctag}
+\subsection*{GCTAG - Get Capability Tag}
+
+\begin{x86opcodetable}
+  \xopcode{NP 0F 7B \emph{/r}}{GCTAG \emph{r64, r/mc}}
+  {RM}{Valid}{Valid}
+  {Store the tag of \emph{r/mc} in \emph{r64}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:reg (w)}{ModRM:r/m (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Sets the destination operand to the \textbf{tag} field of the source
+operand.  The source operand can be a register or memory location.
+
+\subsubsection*{Flags Affected}
+
+ZF is set to 1 if the result is zero.  The CF, PF, AF, SF, and OF
+flags are undefined.

--- a/insn-x86-64/gctype.tex
+++ b/insn-x86-64/gctype.tex
@@ -1,0 +1,25 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{GCTYPE - Get Capability Object Type}
+\insnxeslabel{gctype}
+\subsection*{GCTYPE - Get Capability Object Type}
+
+\begin{x86opcodetable}
+  \xopcode{66 0F 7A \emph{/r}}{GCTYPE \emph{r64, r/mc}}
+  {RM}{Valid}{Valid}
+  {Store the object type of \emph{r/mc} in \emph{r64}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:reg (w)}{ModRM:r/m (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Sets the destination operand to the \textbf{otype} field of the source
+operand.  The source operand can be a register or memory location.
+
+\subsubsection*{Flags Affected}
+
+ZF is set to 1 if the result is zero.  SF is set to 1 if the result is
+less than zero. The CF, PF, AF, and OF flags are undefined.

--- a/insn-x86-64/jmp.tex
+++ b/insn-x86-64/jmp.tex
@@ -1,0 +1,63 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{JMP - Jump}
+\insnxeslabel{jmp}
+\subsection*{JMP - Jump}
+
+\begin{x86opcodetable}
+  \xopcode{E9 \emph{cw}}{JMP \emph{rel16}}
+  {D}{Invalid}{N.S.}
+  {Jump near, relative displacement.}
+  \xopcode{E9 \emph{cd}}{JMP \emph{rel32}}
+  {D}{Valid}{Valid}
+  {Jump near, relative displacement, 32-bit displacement sign-extended
+    to 64-bits.}
+  \xopcode{FF /4}{JMP \emph{r/m16}}
+  {M}{N.E.}{N.S.}
+  {Jump near, absolute indirect, address given in \emph{r/m16}.}
+  \xopcode{FF /4}{JMP \emph{r/m32}}
+  {M}{N.E.}{N.S.}
+  {Jump near, absolute indirect, address given in \emph{r/m32}.}
+  \xopcode{FF /4}{JMP \emph{r/m64}}
+  {M}{Invalid}{Valid}
+  {Jump near, absolute indirect, address given in \emph{r/m64}.}
+  \xopcode{FF /4}{JMP \emph{r/mc}}
+  {M}{Valid}{Valid}
+  {Jump near, absolute indirect, address given in \emph{r/mc}.}
+  \xopcode{EA \emph{cd}}{JMP \emph{ptr16:16}}
+  {D}{N.E.}{Invalid}
+  {Jump far, absolute, address in operand.}
+  \xopcode{EA \emph{cp}}{JMP \emph{ptr16:32}}
+  {D}{N.E.}{Invalid}
+  {Jump far, absolute, address in operand.}
+  \xopcode{FF /5}{JMP \emph{m16:16}}
+  {M}{Valid}{Valid}
+  {Jump far, absolute indirect, address given in \emph{m16:16}.}
+  \xopcode{FF /5}{JMP \emph{m16:32}}
+  {M}{Valid}{Valid}
+  {Jump far, absolute indirect, address given in \emph{m16:32}.}
+  \xopcode{REX.W FF /5}{JMP \emph{m16:64}}
+  {M}{Valid}{Valid}
+  {Jump far, absolute indirect, address given in \emph{m16:64}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{D}{Offset}{NA}{NA}{NA}
+  \xopen{M}{ModRM:r/m (r)}{NA}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Branches to the location specified by the first operand.  In 64-bit
+mode the \insnnoref{CAP} prefix can be used with opcode \texttt{FF /4}
+to select the capability operand size instead of 64-bit.  In
+capability mode, \texttt{FF /4} supports only the capability operand
+size.
+
+Relative jumps always apply the relative displacement to the address
+of the next instruction to compute a new value of the \textbf{address}
+field of \CIP{}.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/lctags.tex
+++ b/insn-x86-64/lctags.tex
@@ -1,0 +1,32 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{LCTAGS - Load Capability Tags}
+\insnxeslabel{lctags}
+\subsection*{LCTAGS - Load Capability Tags}
+
+\begin{x86opcodetable}
+  \xopcode{2F \emph{/r}}{LCTAGS \emph{r64, m8}}
+  {RM}{Valid}{Valid}
+  {Load bitmask of capability tags of \emph{m8} into \emph{r64}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:Reg (w)}{ModRM:r/m (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Loads a packed bitmask of capability tags for a stride of capabilities
+in memory starting at the source operand and stores the bitmask in the
+destination operand.  Bit 0 corresponds to tag for the capability at
+the address of the source operand.  The authorizing capability for the
+source operand must include \cappermL{} and \cappermLC{} and authorize
+access to the entire stride of capabilities.  The source operand
+address must also be aligned to a stride of capabilities.
+
+If this instruction fails, it raises either a Capability Violation
+Fault (see Section~\ref{sec:x86:capability-fault}) or a Page Fault.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/lea.tex
+++ b/insn-x86-64/lea.tex
@@ -1,0 +1,26 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{LEA - Load Effective Address}
+\insnxeslabel{lea}
+\subsection*{LEA - Load Effective Address}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + 8D \emph{/r}}{LEA \emph{rc, m}}
+  {RM}{Valid}{Valid}
+  {Store effective capability address of \emph{m} in \emph{rc}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:reg (w)}{ModRM:r/m (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Computes the effective capability of the second operand and stores the
+result in the first operand.  When used with the \insnnoref{CAP}
+prefix, the effective address is always computed using
+capability-aware addressing.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/lods.tex
+++ b/insn-x86-64/lods.tex
@@ -1,0 +1,31 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{LODS/LODSC - Load String}
+\insnxeslabel{lods}
+\subsection*{LODS/LODSC - Load String}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + AD}{LODS \emph{mc}}
+  {ZO}{Valid}{Valid}
+  {Load capability at address (C|R)SI into CAX.}
+  \xopcode{CAP + AD}{LODSC}
+  {ZO}{Valid}{Valid}
+  {Load capability at address (C|R)SI into CAX.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{ZO}{NA}{NA}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Loads a capablity from the source operand into the \CAX{} register.
+The source operand is a memory location identified by the \RSI{} or
+\CSI{} register (depending on the addressing mode).  After the
+capability is loaded from memory, the address register is incremented
+or decremented by the size of a capability according to the setting of
+\texttt{DF} in \RFLAGS{}.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/mov.tex
+++ b/insn-x86-64/mov.tex
@@ -1,0 +1,44 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{MOV - Move}
+\insnxeslabel{mov}
+\subsection*{MOV - Move}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + 89 \emph{/r}}{MOV \emph{r/mc, rc}}
+  {MR}{Valid}{Valid}
+  {Move \emph{rc} to \emph{r/mc}.}
+  \xopcode{CAP + 8B \emph{/r}}{MOV \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Move \emph{r/mc} to \emph{rc}.}
+  \xopcode{CAP + C7 \emph{/0 id}}{MOV \emph{r/mc, imm32}}
+  {MI}{Valid}{Valid}
+  {Move \emph{imm32 sign-extended to 64-bits} to \emph{r/mc}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{MR}{ModRM:r/m (w)}{ModRM:reg (r)}{NA}{NA}
+  \xopen{RM}{ModRM:Reg (w)}{ModRM:r/m (r)}{NA}{NA}
+  \xopen{MI}{ModRM:r/m (w)}{imm32}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Copies the source operand to the destination operand. The destination
+operand can be a register or a memory location. The source operand can
+be an immediate, a register, or a memory location.  If the source
+operand is an immediate, the value is sign-extended to 64-bits and
+used as the address of a NULL-derived capability.
+
+Note that some \insnnoref{MOV} opcodes such as \texttt{B8+ rw} and
+\texttt{C6 /0} are not extended to support the \insnnoref{CAP} prefix
+as the behavior would be identical.  The \texttt{C7 /0} opcode is
+extended primarily to support storing constants such as NULL to
+capabilities in memory without requiring an intermediate register.
+
+The \texttt{A1} and \texttt{A3} opcodes are not extended to support
+capabilities.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/movcap.tex
+++ b/insn-x86-64/movcap.tex
@@ -1,0 +1,39 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{MOV - Move to/from Additional Capability Registers}
+\insnxeslabel{movcap}
+\subsection*{MOV - Move to/from Additional Capability Registers}
+
+\begin{x86opcodetable}
+  \xopcode{0F 24 \emph{/r}}{MOV \emph{rc,} CFS/CGS/DDC}
+  {MR}{Valid}{Valid}
+  {Move additional capability register to \emph{rc}.}
+  \xopcode{0F 25 \emph{/r}}{MOV CFS/CGS/DDC\emph{, rc}}
+  {RM}{Valid}{Valid}
+  {Move \emph{rc} to additional capability register.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{MR}{ModRM:r/m (w)}{ModRM:reg (r)}{NA}{NA}
+  \xopen{RM}{ModRM:reg (w)}{ModRM:r/m (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Moves the contents of an additional capability register to a
+general-purpose capability register or vice versa.
+
+Similar to the \insnnoref{MOV} opcodes for control and debug
+registers, the \textbf{reg} field of the ModRM byte always identifies
+the additional capability register to read or write.  The \textbf{mod}
+field of ModRM is ignored, and the \textbf{r/m} field identifies the
+general-purpose capability register.  Attempts to reference invalid
+additional capability registers will raise a UD\# exception.
+
+Attempts to access additional capability registers other than \CFS{},
+\CGS{}, or \DDC{} from a privilege level other than 0 will raise a
+GP\#(0) exception.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/movnti.tex
+++ b/insn-x86-64/movnti.tex
@@ -1,0 +1,24 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{MOVNTI - Store Using Non-Temporal Hint}
+\insnxeslabel{movnti}
+\subsection*{MOVNTI - Store Using Non-Temporal Hint}
+
+\begin{x86opcodetable}
+  \xopcode{NP CAP + 0F C3 \emph{/r}}{MOV \emph{mc, rc}}
+  {MR}{Valid}{Valid}
+  {Move \emph{rc} to \emph{mc} using non-temporal hint.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{MR}{ModRM:r/m (w)}{ModRM:reg (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Moves the capability in the source operand to the destination operand
+using a non-temporal hint.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/movs.tex
+++ b/insn-x86-64/movs.tex
@@ -1,0 +1,34 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{MOVS/MOVSC - Move Data from String
+  to String}
+\insnxeslabel{movs}
+\subsection*{MOVS/MOVSC - Move Data from String to String}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + A5}{MOVS \emph{mc, mc}}
+  {ZO}{Valid}{Valid}
+  {Move capability from address (C|R)SI to (C|R)DI.}
+  \xopcode{CAP + A5}{MOVSC}
+  {ZO}{Valid}{Valid}
+  {Move capability from address (C|R)SI to (C|R)DI.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{ZO}{NA}{NA}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Moves a capablity from the source operand to the destination operand.
+The source operand is a memory location identified by the \RSI{} or
+\CSI{} register (depending on the addressing mode).  The destination
+operand is a memory location identified by the \RDI{} or \CDI{}
+register (depending on the addressing mode).  After the capability is
+copied, the address registers are incremented or decremented by the
+size of a capability according to the setting of \texttt{DF} in
+\RFLAGS{}.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/or.tex
+++ b/insn-x86-64/or.tex
@@ -1,0 +1,53 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{OR - Logical Inclusive OR}
+\insnxeslabel{or}
+\subsection*{OR - Logical Inclusive OR}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + 0D \emph{id}}{OR CAX\emph{, imm32}}
+  {I}{Valid}{Valid}
+  {Bitwise inclusive OR of \emph{imm32 sign-extended to 64-bits} with
+    the address field of CAX.}
+  \xopcode{CAP + 81 /1 \emph{id}}{OR \emph{r/mc, imm32}}
+  {MI}{Valid}{Valid}
+  {Bitwise inclusive OR of \emph{imm32 sign-extended to 64-bits} with
+    the address field of \emph{r/mc}.}
+  \xopcode{CAP + 83 /1 \emph{ib}}{OR \emph{r/mc, imm8}}
+  {MI}{Valid}{Valid}
+  {Bitwise inclusive OR of \emph{sign}-extended \emph{imm8} with the
+    address field of \emph{r/mc}.}
+  \xopcode{CAP + 09 \emph{/r}}{OR \emph{r/mc, r64}}
+  {MR}{Valid}{Valid}
+  {Bitwise inclusive OR of \emph{r64} with the address field of
+    \emph{r/mc}.}
+  \xopcode{CAP + 0B \emph{/r}}{OR \emph{rc, r/m64}}
+  {RM}{Valid}{Valid}
+  {Bitwise inclusive OR of \emph{r/m64} with the address field of
+    \emph{rc}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:Reg (r,w)}{ModRM:r/m (r)}{NA}{NA}
+  \xopen{MR}{ModRM:r/m (r,w)}{ModRM:reg (r)}{NA}{NA}
+  \xopen{MI}{ModRM:r/m (r,w)}{imm8/32}{NA}{NA}
+  \xopen{I}{CAX}{imm32}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Derives a new capability from the destination operand whose
+\textbf{address} field is set to the bitwise inclusive OR of the
+source operand and the \textbf{address} field of the destination
+operand and then stores the result in the destination operand. The
+destination operand can be a register or a memory location. The source
+operand can be an immediate, a register, or a memory location.
+
+If the new value of the \textbf{address} field makes the resulting
+capability unrepresentable, the \textbf{tag} field in the resulting
+capability is cleared.
+
+\subsubsection*{Flags Affected}
+
+The OF, SF, ZF, AF, CF, and PF flags are set according to the value of
+the resulting \textbf{address} field.

--- a/insn-x86-64/pop.tex
+++ b/insn-x86-64/pop.tex
@@ -1,0 +1,71 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{POP - Pop Value from the Stack}
+\insnxeslabel{pop}
+\subsection*{POP - Pop Value from the Stack}
+
+\begin{x86opcodetable}
+  \xopcode{8F /0}{POP \emph{r/m16}}
+  {M}{N.E.}{Valid}
+  {Pop \emph{r/m16}.}
+  \xopcode{8F /0}{POP \emph{r/m32}}
+  {M}{N.E.}{N.E.}
+  {Pop \emph{r/m32}.}
+  \xopcode{8F /0}{POP \emph{r/m64}}
+  {M}{Valid}{Valid}
+  {Pop \emph{r/m64}.}
+  \xopcode{8F /0}{POP \emph{r/mc}}
+  {M}{Valid}{Valid}
+  {Pop \emph{r/mc}.}
+  \xopcode{58+\emph{rw}}{POP \emph{r16}}
+  {O}{N.E.}{Valid}
+  {Pop \emph{r16}.}
+  \xopcode{58+\emph{rd}}{POP \emph{r32}}
+  {O}{N.E.}{N.E.}
+  {Pop \emph{r32}.}
+  \xopcode{58+\emph{ro}}{POP \emph{r64}}
+  {O}{Valid}{Valid}
+  {Pop \emph{r64}.}
+  \xopcode{58+\emph{rc}}{POP \emph{rc}}
+  {O}{Valid}{Valid}
+  {Pop \emph{rc}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{M}{ModRM:r/m (w)}{NA}{NA}{NA}
+  \xopen{O}{opcode + rd (w)}{NA}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Stores the value at the top of the stack in the destination operand
+and increments the stack pointer.  The following extensions apply to
+these instructions in 64-bit mode:
+
+\begin{itemize}
+  \item Address size: The 0x07 prefix selects a capability-aware
+    address.
+
+  \item Operand size: The \insnnoref{CAP} prefix selects a capability
+    operand size.
+\end{itemize}
+
+In capability mode, the various sizes are:
+
+\begin{itemize}
+  \item Address size: The default addressing mode uses
+    capability-aware addressing.  64-bit addresses can be used by
+    specifying the 0x07 prefix.
+
+  \item Operand size: The default operand size is a capability.  If
+    the \insnnoref{CAP} prefix is specified, the operand size is
+    64-bits.  16-bit and 32-bit operands cannot be used in capability
+    mode.
+
+  \item Stack-address size: In capability mode the stack pointer is
+    always \CSP{}.
+\end{itemize}
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/push.tex
+++ b/insn-x86-64/push.tex
@@ -1,0 +1,84 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{PUSH - Push Value Onto the Stack}
+\insnxeslabel{push}
+\subsection*{PUSH - Push Value Onto the Stack}
+
+\begin{x86opcodetable}
+  \xopcode{FF /6}{PUSH \emph{r/m16}}
+  {M}{N.E.}{Valid}
+  {Push \emph{r/m16}.}
+  \xopcode{FF /6}{PUSH \emph{r/m32}}
+  {M}{N.E.}{N.E.}
+  {Push \emph{r/m32}.}
+  \xopcode{FF /6}{PUSH \emph{r/m64}}
+  {M}{Valid}{Valid}
+  {Push \emph{r/m64}.}
+  \xopcode{FF /6}{PUSH \emph{r/mc}}
+  {M}{Valid}{Valid}
+  {Push \emph{r/mc}.}
+  \xopcode{50+\emph{rw}}{PUSH \emph{r16}}
+  {O}{N.E.}{Valid}
+  {Push \emph{r16}.}
+  \xopcode{50+\emph{rd}}{PUSH \emph{r32}}
+  {O}{N.E.}{N.E.}
+  {Push \emph{r32}.}
+  \xopcode{50+\emph{ro}}{PUSH \emph{r64}}
+  {O}{Valid}{Valid}
+  {Push \emph{r64}.}
+  \xopcode{50+\emph{rc}}{PUSH \emph{rc}}
+  {O}{Valid}{Valid}
+  {Push \emph{rc}.}
+  \xopcode{6A \emph{ib}}{PUSH \emph{imm8}}
+  {I}{Valid}{Valid}
+  {Push \emph{imm8}.}
+  \xopcode{68 \emph{iw}}{PUSH \emph{imm16}}
+  {I}{Valid}{Valid}
+  {Push \emph{imm16}.}
+  \xopcode{68 \emph{id}}{PUSH \emph{imm32}}
+  {I}{Valid}{Valid}
+  {Push \emph{imm32}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{M}{ModRM:r/m (r)}{NA}{NA}{NA}
+  \xopen{O}{opcode + rd (r)}{NA}{NA}{NA}
+  \xopen{I}{imm8/16/32}{NA}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Decrements the stack pointer and stores the source operand on the
+stack.  The following extensions apply to these instructions in 64-bit
+mode:
+
+\begin{itemize}
+  \item Address size: The 0x07 prefix selects a capability-aware
+    address.
+
+  \item Operand size: The \insnnoref{CAP} prefix selects a capability
+    operand size.  When a capability operand size is used, immediate
+    operands are sign-extended to 64-bits and the result used as the
+    address of a null-derived capability.
+\end{itemize}
+
+In capability mode, the various sizes are:
+
+\begin{itemize}
+  \item Address size: The default addressing mode uses
+    capability-aware addressing.  64-bit addresses can be used by
+    specifying the 0x07 prefix.
+
+  \item Operand size: The default operand size is a capability.  If
+    the \insnnoref{CAP} prefix is specified, the operand size is
+    64-bits.  Immediate operands are sign-extended to 64-bits.  When a
+    capability operand size is used, sign-extended immediate operands
+    are used as the address of a null-derived capability.
+
+  \item Stack-address size: In capability mode the stack pointer is
+    always \CSP{}.
+\end{itemize}
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/ret.tex
+++ b/insn-x86-64/ret.tex
@@ -1,0 +1,41 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{RET - Return from Procedure}
+\insnxeslabel{ret}
+\subsection*{RET - Return from Procedure}
+
+\begin{x86opcodetable}
+  \xopcode{C3}{RET}
+  {ZO}{Valid}{Valid}
+  {Near return.}
+  \xopcode{CB}{RET}
+  {ZO}{Valid}{Valid}
+  {Far return.}
+  \xopcode{C2 \emph{iw}}{RET \emph{imm16}}
+  {I}{Valid}{Valid}
+  {Near return and pop \emph{imm16} bytes from stack.}
+  \xopcode{CA \emph{iw}}{RET \emph{imm16}}
+  {I}{Valid}{Valid}
+  {Far return and pop \emph{imm16} bytes from stack.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{ZO}{NA}{NA}{NA}{NA}
+  \xopen{I}{imm16}{NA}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Pops return address from the stack and transfers control to the popped
+address.  In 64-bit mode the \insnnoref{CAP} prefix can be used with
+near returns to select the capability operand size instead of 64-bit.
+In capability mode, near returns always use the capability operand
+size.
+
+Near returns which use a capability operand size always pop a
+capability off of the stack to load into \CIP{} rather than popping
+off the new value of \RIP{}.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/scaddr.tex
+++ b/insn-x86-64/scaddr.tex
@@ -1,0 +1,32 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{SCADDR - Set Capability Address}
+\insnxeslabel{scaddr}
+\subsection*{SCADDR - Set Capability Address}
+
+\begin{x86opcodetable}
+  \xopcode{16 \emph{/r}}{SCADDR \emph{r/mc, r64}}
+  {MR}{Valid}{Valid}
+  {Set the address field of \emph{r/mc} to \emph{r64}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{MR}{ModRM:r/m (r, w)}{ModRM:reg (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Sets the \textbf{address} field of the destination operand to the
+source operand and stores the result in the destination operand.  The
+destination operand can be a register or memory location; the source
+operand can be a register.  If the destination operand is sealed and
+tagged, the destination operand is set to its original value with the
+\textbf{tag} field cleared.
+
+If the new value of the \textbf{address} field makes the resulting
+capability unrepresentable, the \textbf{tag} field in the resulting
+capability is cleared.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/scbnd.tex
+++ b/insn-x86-64/scbnd.tex
@@ -1,0 +1,42 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{SCBND - Set Capability Bounds}
+\insnxeslabel{scbnd}
+\subsection*{SCBND - Set Capability Bounds}
+
+\begin{x86opcodetable}
+  \xopcode{17 \emph{/r}}{SCBND \emph{r/mc, r64}}
+  {MR}{Valid}{Valid}
+  {Set bounds of \emph{r/mc} to \emph{r64}.}
+  \xopcode{37 /0 \emph{id}}{SCBND \emph{r/mc, imm32}}
+  {MI}{Valid}{Valid}
+  {Set bounds of \emph{r/mc} to zero-extended \emph{imm32}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{MR}{ModRM:r/m (r, w)}{ModRM:reg (r)}{NA}{NA}
+  \xopen{MI}{ModRM:r/m (r, w)}{imm32}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Derives a new capability from the destination operand and source
+operand and then store the result in the destination operand.  The
+destination operand can be a register or memory location; the source
+operand can be an immediate or a register.  When an immediate value is
+used as an operand, it is zero-extended.
+
+The new capability's \textbf{base} field is set to the current
+\textbf{address} field of the destination operand, and the
+\textbf{length} field is set to the source operand.  If the resulting
+capability cannot be represented exactly, the \textbf{base} will be
+rounded down and the \textbf{length} will be rounded up by the
+smallest amount needed to form a representable capability covering the
+requested bounds.  If the original capability is sealed or the bounds
+of the new capability exceed the original capability, the \textbf{tag}
+field in the resulting capability is cleared.
+
+\subsubsection*{Flags Affected}
+
+The ZF flag is set to the value of the \textbf{tag} field in the
+resulting capability.  The CF, PF, AF, SF, and OF flags are undefined.

--- a/insn-x86-64/scbnde.tex
+++ b/insn-x86-64/scbnde.tex
@@ -1,0 +1,43 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{SCBNDE - Set Exact Capability Bounds}
+\insnxeslabel{scbnde}
+\subsection*{SCBNDE - Set Exact Capability Bounds}
+
+\begin{x86opcodetable}
+  \xopcode{27 \emph{/r}}{SCBNDE \emph{r/mc, r64}}
+  {MR}{Valid}{Valid}
+  {Set bounds of \emph{r/mc} to \emph{r64}.}
+  \xopcode{37 /1 \emph{id}}{SCBNDE \emph{r/mc, imm32}}
+  {MI}{Valid}{Valid}
+  {Set bounds of \emph{r/mc} to zero-extended \emph{imm32}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{MR}{ModRM:r/m (r, w)}{ModRM:reg (r)}{NA}{NA}
+  \xopen{MI}{ModRM:r/m (r, w)}{imm32}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Derives a new capability from the destination operand and source
+operand and then store the result in the destination operand.  The
+destination operand can be a register or memory location; the source
+operand can be an immediate or a register.  When an immediate value is
+used as an operand, it is zero-extended.
+
+The new capability's \textbf{base} field is set to the current
+\textbf{address} field of the destination operand, and the
+\textbf{length} field is set to the source operand.  If the resulting
+capability cannot be represented exactly, the \textbf{tag} field will
+be cleared, the \textbf{base} will be rounded down, and the
+\textbf{length} will be rounded up by the smallest amount needed to
+form a representable capability covering the requested bounds.  If the
+original capability is sealed or the bounds of the new capability
+exceed the original capability, the \textbf{tag} field in the
+resulting capability is cleared.
+
+\subsubsection*{Flags Affected}
+
+The ZF flag is set to the value of the \textbf{tag} field in the
+resulting capability.  The CF, PF, AF, SF, and OF flags are undefined.

--- a/insn-x86-64/scoff.tex
+++ b/insn-x86-64/scoff.tex
@@ -1,0 +1,32 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{SCOFF - Set Capability Offset}
+\insnxeslabel{scoff}
+\subsection*{SCOFF - Set Capability Offset}
+
+\begin{x86opcodetable}
+  \xopcode{66 0F 0C \emph{/r}}{SCOFF \emph{r/mc, r64}}
+  {MR}{Valid}{Valid}
+  {Set offset of \emph{r/mc} to \emph{r64}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{MR}{ModRM:r/m (r, w)}{ModRM:reg (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Sets the \textbf{offset} field of the destination operand to the
+source operand and stores the result in the destination operand.  The
+destination operand can be a register or memory location; the source
+operand can be a register.  If the destination operand is sealed and
+tagged, the destination operand is set to its original value with the
+\textbf{tag} field cleared.
+
+If the new value of the \textbf{offset} field makes the resulting
+capability unrepresentable, the \textbf{tag} field in the resulting
+capability is cleared.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/seal.tex
+++ b/insn-x86-64/seal.tex
@@ -1,0 +1,28 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{SEAL - Seal Capability}
+\insnxeslabel{seal}
+\subsection*{SEAL - Seal Capability}
+
+\begin{x86opcodetable}
+  \xopcode{F2 0F 0C \emph{/r}}{SEAL \emph{r/mc, rc}}
+  {MR}{Valid}{Valid}
+  {Seal \emph{r/mc} with type from the address field of \emph{rc}}.
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{MR}{ModRM:r/m (r, w)}{ModRM:reg (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Seals the destination operand with the \textbf{otype} equal to the
+\textbf{address} field of the source operand and stores the result in
+the destination operand.  If the sealing operation fails, the
+destination operand is set to the original value of the destination
+operand with the \textbf{tag} field cleared.
+
+\subsubsection*{Flags Affected}
+
+The ZF flag is set to 1 if the sealing operation succeeds; otherwise
+0.  The CF, PF, AF, SF, and OF flags are undefined.

--- a/insn-x86-64/sentry.tex
+++ b/insn-x86-64/sentry.tex
@@ -1,0 +1,25 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{SENTRY - Seal Capability as a Sentry}
+\insnxeslabel{sentry}
+\subsection*{SENTRY - Seal Capability as a Sentry}
+
+\begin{x86opcodetable}
+  \xopcode{0E /0}{SENTRY \emph{r/mc}}
+  {M}{Valid}{Valid}
+  {Seal \emph{r/mc} as a sentry.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{M}{ModRM:r/m (r, w)}{NA}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Seals the destination operand as a sentry capability.  If the sealing
+operation fails, leave the destination operand unchanged.
+
+\subsubsection*{Flags Affected}
+
+The ZF flag is set to 1 if the sealing operation succeeds; otherwise
+0.  The CF, PF, AF, SF, and OF flags are undefined.

--- a/insn-x86-64/stos.tex
+++ b/insn-x86-64/stos.tex
@@ -1,0 +1,31 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{STOS/STOSC - Store String}
+\insnxeslabel{stos}
+\subsection*{STOS/STOSC - Store String}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + AB}{STOS \emph{mc}}
+  {ZO}{Valid}{Valid}
+  {Store CAX at address (C|R)DI.}
+  \xopcode{CAP + AB}{STOSC}
+  {ZO}{Valid}{Valid}
+  {Store CAX at address (C|R)DI.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{ZO}{NA}{NA}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Stores capability in the \CAX{} register into the destination operand.
+The destination operand is a memory location identified by the \RDI{}
+or \CDI{} register (depending on the addressing mode).  After the
+capability is stored to memory, the address register is incremented or
+decremented by the size of a capability according to the setting of
+\texttt{DF} in \RFLAGS{}.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/sub.tex
+++ b/insn-x86-64/sub.tex
@@ -1,0 +1,50 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{SUB - Subtract}
+\insnxeslabel{sub}
+\subsection*{SUB - Subtract}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + 2D \emph{id}}{SUB CAX\emph{, imm32}}
+  {I}{Valid}{Valid}
+  {Subtract \emph{imm32 sign-extended to 64-bits} from the address field of
+    CAX.}
+  \xopcode{CAP + 81 /5 \emph{id}}{SUB \emph{r/mc, imm32}}
+  {MI}{Valid}{Valid}
+  {Subract \emph{imm32 sign-extended to 64-bits} from the address field of
+    \emph{r/mc}.}
+  \xopcode{CAP + 83 /5 \emph{ib}}{SUB \emph{r/mc, imm8}}
+  {MI}{Valid}{Valid}
+  {Subtract \emph{sign}-extended \emph{imm8} from the address field of
+    \emph{r/mc}.}
+  \xopcode{CAP + 29 \emph{/r}}{SUB \emph{r/mc, r64}}
+  {MR}{Valid}{Valid}
+  {Subtract \emph{r64} from the address field of \emph{r/mc}.}
+  \xopcode{CAP + 2B \emph{/r}}{SUB \emph{rc, r/m64}}
+  {RM}{Valid}{Valid}
+  {Subtract \emph{r/m64} from the address field of \emph{rc}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:Reg (r,w)}{ModRM:r/m (r)}{NA}{NA}
+  \xopen{MR}{ModRM:r/m (r,w)}{ModRM:reg (r)}{NA}{NA}
+  \xopen{MI}{ModRM:r/m (r,w)}{imm8/32}{NA}{NA}
+  \xopen{I}{CAX}{imm32}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Subtracts the source operand from the \textbf{address} field of the
+destination operand and then stores the result in the destination
+operand. The destination operand can be a register or a memory
+location. The source operand can be an immediate, a register, or a
+memory location.
+
+If the new value of the \textbf{address} field makes the resulting
+capability unrepresentable, the \textbf{tag} field in the resulting
+capability is cleared.
+
+\subsubsection*{Flags Affected}
+
+The OF, SF, ZF, AF, CF, and PF flags are set according to the value of
+the resulting \textbf{address} field.

--- a/insn-x86-64/unseal.tex
+++ b/insn-x86-64/unseal.tex
@@ -1,0 +1,28 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{UNSEAL - Unseal Capability}
+\insnxeslabel{unseal}
+\subsection*{UNSEAL - Unseal Capability}
+
+\begin{x86opcodetable}
+  \xopcode{F3 0F 0C \emph{/r}}{UNSEAL \emph{r/mc, rc}}
+  {MR}{Valid}{Valid}
+  {Unseal \emph{r/mc} using \emph{rc} as the authority}.
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{MR}{ModRM:r/m (r, w)}{ModRM:reg (r)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Unseals the destination operand using the source operand as the
+unsealing authority and stores the result in the destination operand.
+If the unsealing operation fails, the destination operand is set to
+the original value of the destination operand with the \textbf{tag}
+field cleared.
+
+\subsubsection*{Flags Affected}
+
+The ZF flag is set to 1 if the unsealing operation succeeds; otherwise
+0.  The CF, PF, AF, SF, and OF flags are undefined.

--- a/insn-x86-64/xadd.tex
+++ b/insn-x86-64/xadd.tex
@@ -1,0 +1,37 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{XADD - Exchange and Add}
+\insnxeslabel{xadd}
+\subsection*{XADD - Exchange and Add}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + 0F C1 \emph{/r}}{XADD \emph{r/mc, rc, r64}}
+  {MRR}{Valid}{Valid}
+  {Load original value of \emph{r/mc} into \emph{rc}.  Add \emph{r64}
+    to the address field of \emph{r/mc}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{MRR}{ModRM:r/m (r,w)}{ModRM:reg (w)}{ModRM:reg (r)}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Stores the original value of the destination (first) operand in the second
+operand.  Derives a new capability value by adding the third operand
+to the \textbf{address} field of the destination operand and stores
+the result in the destination operand.  Note that the third operand
+must be the 64-bit register which aliases the low 64-bits of the
+second operand.
+
+If the new value of the \textbf{address} field makes the resulting
+capability unrepresentable, the \textbf{tag} field in the resulting
+capability is cleared.
+
+The instruction can be used with a \insnnoref{LOCK} prefix to execute
+atomically.
+
+\subsubsection*{Flags Affected}
+
+The OF, SF, ZF, AF, CF, and PF flags are set according to the value of
+the resulting \textbf{address} field.

--- a/insn-x86-64/xchg.tex
+++ b/insn-x86-64/xchg.tex
@@ -1,0 +1,40 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{XCHG - Exchange}
+\insnxeslabel{xchg}
+\subsection*{XCHG - Exchange}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + 90+\emph{rc}}{XCHG CAX, \emph{rc}}
+  {O}{Valid}{Valid}
+  {Exchange \emph{rc} with CAX.}
+  \xopcode{CAP + 90+\emph{rc}}{XCHG \emph{rc}, CAX}
+  {O}{Valid}{Valid}
+  {Exchange CAX with \emph{rc}.}
+  \xopcode{CAP + 87 \emph{/r}}{XCHG \emph{r/mc, rc}}
+  {MR}{Valid}{Valid}
+  {Exchange \emph{rc} with \emph{r/mc}.}
+  \xopcode{CAP + 87 \emph{/r}}{XCHG \emph{rc, r/mc}}
+  {RM}{Valid}{Valid}
+  {Exchange \emph{r/mc} with \emph{rc}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{O}{CAX (r,w)}{opcode + rc (r, w)}{NA}{NA}
+  \xopen{O}{opcode + rc (r, w)}{CAX (r,w)}{NA}{NA}
+  \xopen{MR}{ModRM:r/m (r,w)}{ModRM:reg (r, w)}{NA}{NA}
+  \xopen{RM}{ModRM:reg (r,w)}{ModRM:r/m (r, w)}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Exchanges the contents of the source and destination operands.  The
+operands can be two general-purpose registers or a general-purpose
+register and a memory location.
+
+The specific opcode \texttt{90} would remain a single byte
+\insnnoref{NOP} that would not alter the value of \CAX{}.
+
+\subsubsection*{Flags Affected}
+
+None

--- a/insn-x86-64/xor.tex
+++ b/insn-x86-64/xor.tex
@@ -1,0 +1,51 @@
+\clearpage
+\phantomsection
+\addcontentsline{toc}{subsection}{XOR - Logical Exclusive OR}
+\insnxeslabel{xor}
+\subsection*{XOR - Logical Exclusive OR}
+
+\begin{x86opcodetable}
+  \xopcode{CAP + 35 \emph{id}}{XOR CAX\emph{, imm32}}
+  {I}{Valid}{Valid}
+  {Bitwise exclusive OR of \emph{imm32 sign-extended to 64-bits} with
+    the address field of CAX.}
+  \xopcode{CAP + 81 /6 \emph{id}}{XOR \emph{r/mc, imm32}}
+  {MI}{Valid}{Valid}
+  {Bitwise exclusive OR of \emph{imm32 sign-extended to 64-bits} with
+    the address field of \emph{r/mc}.}
+  \xopcode{CAP + 83 /6 \emph{ib}}{XOR \emph{r/mc, imm8}}
+  {MI}{Valid}{Valid}
+  {Bitwise exclusive OR of \emph{sign}-extended \emph{imm8} with the
+    address field of \emph{r/mc}.}
+  \xopcode{CAP + 31 \emph{/r}}{XOR \emph{r/mc, r64}}
+  {MR}{Valid}{Valid}
+  {Bitwise exclusive OR of \emph{r64} with the address field of \emph{r/mc}.}
+  \xopcode{CAP + 33 \emph{/r}}{XOR \emph{rc, r/m64}}
+  {RM}{Valid}{Valid}
+  {Bitwise exclusive OR of \emph{r/m64} with the address field of \emph{rc}.}
+\end{x86opcodetable}
+
+\begin{x86opentable}
+  \xopen{RM}{ModRM:Reg (r,w)}{ModRM:r/m (r)}{NA}{NA}
+  \xopen{MR}{ModRM:r/m (r,w)}{ModRM:reg (r)}{NA}{NA}
+  \xopen{MI}{ModRM:r/m (r,w)}{imm8/32}{NA}{NA}
+  \xopen{I}{CAX}{imm32}{NA}{NA}
+\end{x86opentable}
+
+\subsubsection*{Description}
+
+Derives a new capability from the destination operand whose
+\textbf{address} field is set to the bitwise exclusive OR of the
+source operand and the \textbf{address} field of the destination
+operand and then stores the result in the destination operand. The
+destination operand can be a register or a memory location. The source
+operand can be an immediate, a register, or a memory location.
+
+If the new value of the \textbf{address} field makes the resulting
+capability unrepresentable, the \textbf{tag} field in the resulting
+capability is cleared.
+
+\subsubsection*{Flags Affected}
+
+The OF, SF, ZF, AF, CF, and PF flags are set according to the value of
+the resulting \textbf{address} field.

--- a/preamble.tex
+++ b/preamble.tex
@@ -10,6 +10,7 @@
 \usepackage{bitset}
 \usepackage{comment}
 \usepackage{graphicx}
+\usepackage{tabularx}
 \usepackage{marginnote}
 \usepackage{booktabs}
 \usepackage{ifthen}
@@ -436,6 +437,8 @@
 \newcommand{\@makeinsncmds}[1]{\@makeinsncmds@explicit{#1}{#1}}
 
 \@makeinsncmds{riscv}
+% Cannot use more intuitive x86 in command names
+\@makeinsncmds{xes}
 
 \newcommand{\definsnarch}[1]{\def\@definsnarch{#1}}
 \@makeinsncmds@explicit{}{\@definsnarch}


### PR DESCRIPTION
This is more of a draft for now.  I started creating more detailed opcode descriptions to add extra details I've been depending on in the toolchain and Sail modeling work.  However, after getting started down this path I think I probably need to move the instruction descriptions out into either a separate top-level section or even a separate chapter as we do for RISC-V (and did for MIPS).  I should also add similar details for existing opcodes extended by the 06 prefix (e.g. ADD).

There's a lot of repetition though so I probably need to gain some inspiration from @jrtc27's RISC-V instruction macros.