### PR TITLE
Remove offsetting from CHERI-x86

### DIFF
--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -110,9 +110,8 @@ architectures:
 \begin{itemize}
 \item Tagged memory with capability-width tag granularity and alignment.
 \item Registers able to hold capabilities are tagged.
-\item \CIP{} transforms and controls program-counter-relative fetches.
-\item \DDC{} transforms and controls memory operands using integer addresses,
-  including relocating access addresses using the capability base and offset.
+\item \CIP{} controls program-counter-relative fetches.
+\item \DDC{} controls memory operands using integer addresses.
 \item Floating point is fully supported, including capability-relative
   floating-point load and store instructions.
 \item General-purpose registers are extended to hold capabilities.
@@ -131,6 +130,10 @@ The following changes are specific to CHERI-x86-64:
  \item CHERI-x86-64 makes use of opcode prefixes to permit altering
    the addressing mode and operand size of individual instructions,
    both in 64-bit mode and capability mode.
+ \item \RIP{} is the full integer value (virtual address) of \CIP{}
+   and not \CIP{}.offset.
+ \item Integer addresses are treated as absolute virtual addresses
+   bounded by \DDC{}, and are not treated as offsets to \DDC{}.base.
  \item x86 exception handling is extended to support capabilities
    including a new architectural stack frame for exception entry and
    return.
@@ -181,8 +184,6 @@ The \RIP{} register (which contains the address of the current
 instruction in the existing x86 architecture)
 would also be extended into a \CIP{} capability.  This would function as
 the equivalent of \PCC{}.
-The value of \RIP{} should be the current offset of \CIP{} rather than the
-integer value (virtual address).
 
 \subsection{Additional Capability Registers}
 \label{sec:x86:additional-caps}
@@ -285,8 +286,9 @@ In capability mode, instructions will use
 the capability-aware addressing mode by default.  Individual
 instructions can toggle between capability-aware and ``plain''
 64-bit addressing via the 0x07 opcode prefix.  Addresses using the
-``plain'' 32-bit or 64-bit addressing will be treated as offsets
-relative to \DDC{}.  Instructions using capability-aware addressing
+``plain'' 32-bit or 64-bit addressing will be constrained by \DDC{}
+(for example, bounds and permissions).
+Instructions using capability-aware addressing
 would always use 64-bit virtual addresses.
 
 The 0x07 prefix would be a Group 4 prefix meaning that a single
@@ -298,7 +300,7 @@ be permitted.
 
 For instructions with register-based memory operands, capability-aware
 addressing would use the capability version of the register rather
-than the virtual address relative to \DDC{}.
+than the integer register as a virtual address constrained by \DDC{}.
 
 For example:
 
@@ -315,7 +317,8 @@ On the other hand,
 mov 0x8(%rbp),%rax
 \end{verbatim}
 
-would read the 64-bit value at an offset of RBP+8 from the \DDC{} capability.
+would read the 64-bit value at the address \RBP{}+8 constraining the
+memory access to the bounds and permissions of the \DDC{} capability.
 Both instructions would use the same opcode aside from the addition of
 an 0x07 opcode prefix.  In capability mode, the second
 instruction would require the prefix.  In plain 64-bit mode,
@@ -353,16 +356,12 @@ This addressing mode uses an immediate offset
 relative to the current value of the instruction
 pointer.  These addresses are known as \RIP{}-relative addresses.
 
-To support existing code, \RIP{}-relative addresses should be resolved
-relative to \DDC{} when using ``plain'' 64-bit addressing.
-Specifically, the value of \RIP{} (offset of \CIP{}) would be added to
-the immediate offset.  The resulting value would then be used as an
-offset relative to \DDC{} for the load or store.
+To support existing code, \RIP{}-relative addresses should be constrained
+by \DDC{} when using ``plain'' 64-bit addressing.
 
 When capability-aware addressing is used, \RIP{}-relative addresses
-should be resolved relative to \CIP{}.
-The immediate offset is applied to \CIP{} and the load
-or store is constrained by the bounds and permissions of \CIP{}.
+would instead be treated as \CIP{}-relative addresses
+constrained by the bounds and permissions of \CIP{}.
 
 \subsubsection{Absolute Addresses}
 
@@ -370,8 +369,8 @@ Memory operands can be encoded without a base register, either as an
 absolute address, or an absolute address added to a scaled index
 register.  If these addresses are not used as offsets relative to
 \CFS{} or \CGS{} as described below in Section~\ref{sec:x86:cfs-cgs},
-they are evaluated as offsets relative to
-\DDC{} including in capability mode.
+they are always constrained by
+\DDC{}, including in capability mode.
 
 \subsubsection{Direct Memory-Offset MOVs}
 
@@ -719,21 +718,21 @@ Absolute near branches would be extended to support capability operands.
 In 64-bit long mode, a capability operand prefix would select a
 capability operand size.  In capability mode, absolute near branches would
 support only capability operands.
-Absolute near branches which use an integer operand would set the offset of the
+Absolute near branches which use an integer operand would set the address of the
 \CIP{} capability while absolute near branches using a capability operand would
 load a new capability into \CIP{}.
-Relative near branches would always modify the offset of the \CIP{}
+Relative near branches would always modify the address of the \CIP{}
 capability and would not support the capability operand prefix.
 
 The size of return addresses pushed to and popped from the
 stack for near branches would be determined by the operand size.
 Capability-sized branches would save and restore a full capability on
 the stack while integer-sized branches would save and restore an
-integer offset.
+integer address.
 
 Far calls, jumps, and returns would not support capability operands.
-Far branches would use the offset portion of the destination address
-to set the offset of \CIP{}.  An attempt to branch to a 32-bit code
+Far branches would
+set the address of \CIP{}.  An attempt to branch to a 32-bit code
 segment in capability mode should raise a General Protection fault
 with the error code set to the destination code segment.
 
@@ -1218,7 +1217,7 @@ following changes:
 \begin{itemize}
   \item Extending the global and local descriptor table format to
     support a new capability call gate which stored a full capability
-    rather than a 64-bit offset.  This will be more invasive than the
+    rather than a 64-bit address.  This will be more invasive than the
     64-bit call gate which depends on the ability to force a number
     of reserved bits in the fourth double word to zero as a sentinel
     type for the second half of a 64-bit call gate.
@@ -1276,14 +1275,14 @@ the start of an interrupt or exception.
 
 The first approach would add two new capability control registers: the Kernel
 Code Capability (\KCC{}) and Kernel Stack Capability (\KSC{}).  Transitions into
-supervisor mode would load new offsets relative to \KCC{} and \KSC{} from
-existing data structures and tables to construct the new \CIP{} and \CSP{}
+supervisor mode would load new addresses from
+existing data structures and tables to derive the new \CIP{} and \CSP{}
 register values.  For example, the current virtual address stored in
-each Interrupt Descriptor Table (\IDT{}) entry would be used as an offset
-relative to \KCC{} to build \CIP{}, and the address stored in the Interrupt
+each Interrupt Descriptor Table (\IDT{}) entry would be used as an
+address to derive a new \CIP{} from \KCC{}, and the address stored in the Interrupt
 Stack Table (\IST{}) entry in the current Task-State Segment (\TSS{}) would
-be used as an offset relative to \KSC{} to build \CSP{}.  Transitions via
-the \insnnoref{SYSCALL} instruction would use the offset from \LSTAR{} to
+be used as an address to derive a new \CSP{} from \KSC{}.  Transitions via
+the \insnnoref{SYSCALL} instruction would use the address from \LSTAR{} to
 construct the new \CIP{}.
 
 This approach does require broad capabilities
@@ -1299,7 +1298,7 @@ invasive change, requiring larger changes to existing systems code, but
 it enables the use of more fine-grained capabilities for each entry
 point.
 
-Setting the desired kernel stack pointers \CSP{} would require a new
+Setting the desired kernel stack pointers in \CSP{} would require a new
 \TSS{} layout that expanded the existing \RSP{} and \IST{} entries to
 capabilities.
 

--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -956,39 +956,6 @@ capability.
     \texttt{SF}, and \texttt{OF}) would be undefined.
 \end{itemize}
 
-\subsubsection{Pointer-Arithmetic Instructions}
-
-These instructions should set \texttt{ZF} in \RFLAGS{} to indicate
-success (set) or failure (clear).  If one of these instructions fails, it
-should not raise an exception.  The value of other status flags
-(\texttt{CF}, \texttt{PF}, \texttt{AF}, \texttt{SF}, and \texttt{OF})
-would be undefined.
-
-\begin{itemize}
-  \item \insnref{CToPtr} r64, rc, r/mc
-
-    If the \textbf{tag} field of \emph{r/mc} is not set or \emph{rc}
-    is sealed and tagged, then set \emph{r64} to 0 and clear
-    \texttt{ZF} in \RFLAGS{}.
-
-    If the \textbf{tag} field of \emph{rc} is not set, then set
-    \emph{r64} to 0 and set \texttt{ZF} in \RFLAGS{} to 1; otherwise,
-    set \emph{r64} to \emph{rc}.\textbf{address} -
-    \emph{r/mc}.\textbf{base} and set \texttt{ZF} in \RFLAGS{} to 1.
-
-  \item \insnref{CFromPtr} rc, r/mc, r64
-
-    If \emph{r64} is 0, then set \emph{rc} to \textbf{NULL} and set
-    \texttt{ZF} to 1.
-
-    If \emph{r/mc} is untagged or sealed, then set \emph{rc} to the
-    \textbf{NULL} capability with the \textbf{address} field set to
-    \emph{r64} and set \texttt{ZF} to 0.
-
-    Otherwise, set \emph{rc} to \emph{r/mc} with its \textbf{offset}
-    replaced by \emph{r64} and set \texttt{ZF} to 1.
-\end{itemize}
-
 \subsubsection{Control-Flow Instructions}
 
 \begin{itemize}


### PR DESCRIPTION
This assumes (and implicitly depends on) #34.