### PR TITLE
x86: Remove far branches from capability mode.

### DIFF
--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -273,6 +273,7 @@ longer be valid:
   \item \insnnoref{LAR}
   \item \insnnoref{LSL}
   \item Direct memory-offset \insnnoref{MOV}
+  \item Far branches (\insnnoref{CALL}, \insnnoref{JMP}, and \insnnoref{RET})
 \end{itemize}
 
 \subsection{Using Capabilities with Memory Address Operands}
@@ -477,7 +478,7 @@ operand when executed in capability mode:
 \begin{itemize}
   \item Near branches.
 
-  \item Instructions other than far branches that implicitly reference
+  \item Instructions that implicitly reference
     the stack pointer (\CSP{}).
 \end{itemize}
 
@@ -621,11 +622,10 @@ Capability-sized branches would save and restore a full capability on
 the stack while integer-sized branches would save and restore an
 integer address.
 
-Far calls, jumps, and returns would not support capability operands.
+Far calls, jumps, and returns would not support capability operands
+and would be invalid in capability mode.
 Far branches would
-set the \textbf{address} field of \CIP{}.  An attempt to branch to a 32-bit code
-segment in capability mode should raise a General Protection fault
-with the error code set to the destination code segment.
+set the \textbf{address} field of \CIP{}.
 
 If the resulting value of \CIP{} after any branch
 is invalid, a capability violation fault would be raised on the branch
@@ -1172,10 +1172,7 @@ have odd alignment requirements due to the 16-bit code selector being
 adjacent to an aligned capability.  Far branches are also little used
 in existing 64-bit x86 programs.  Significantly, 64-bit x86 still
 defaults to 32-bit operands for far branches (unlike near branches
-which are commonly used and default to 64-bit operands).  It may make
-sense to remove far branches other than \insnnoref{IRET} completely
-in capability mode causing the instructions to raise an illegal
-instruction fault.
+which are commonly used and default to 64-bit operands).
 
 \subsection{Direct Memory-Offset MOVs}
 

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -241,6 +241,17 @@ or 64).
   \hline
   A3 & MOV \emph{moffs8},[ER]AX & Move [ER]AX to  (\emph{offset}).\\
   \hline
+  CA & RET \emph{imm16} &
+  Far return and pop \emph{imm16} bytes from stack.\\
+  \hline
+  CB & RET & Far return.\\
+  \hline
+  FF /3 & CALL \emph{m16:xx} &
+  Call far, absolute indirect, address given in \emph{m16:xx}.\\
+  \hline
+  FF /5 & JMP \emph{m16:xx} &
+  Jump far, absolute indirect, address given in \emph{m16:xx}.\\
+  \hline
   0F 02 \emph{/r} & LAR \emph{rxx,rxx/m16} &
   Load access rights.\\
   \hline

--- a/insn-x86-64/call.tex
+++ b/insn-x86-64/call.tex
@@ -31,13 +31,13 @@
   {D}{N.E.}{N.E.}
   {Call far, absolute, address in operand.}
   \xopcode{FF /3}{CALL \emph{m16:16}}
-  {M}{Valid}{Valid}
+  {M}{Invalid}{Valid}
   {Call far, absolute indirect, address given in \emph{m16:16}.}
   \xopcode{FF /3}{CALL \emph{m16:32}}
-  {M}{Valid}{Valid}
+  {M}{Invalid}{Valid}
   {Call far, absolute indirect, address given in \emph{m16:32}.}
   \xopcode{REX.W FF /3}{CALL \emph{m16:64}}
-  {M}{Valid}{Valid}
+  {M}{Invalid}{Valid}
   {Call far, absolute indirect, address given in \emph{m16:64}.}
 \end{x86opcodetable}
 

--- a/insn-x86-64/jmp.tex
+++ b/insn-x86-64/jmp.tex
@@ -31,13 +31,13 @@
   {D}{N.E.}{Invalid}
   {Jump far, absolute, address in operand.}
   \xopcode{FF /5}{JMP \emph{m16:16}}
-  {M}{Valid}{Valid}
+  {M}{Invalid}{Valid}
   {Jump far, absolute indirect, address given in \emph{m16:16}.}
   \xopcode{FF /5}{JMP \emph{m16:32}}
-  {M}{Valid}{Valid}
+  {M}{Invalid}{Valid}
   {Jump far, absolute indirect, address given in \emph{m16:32}.}
   \xopcode{REX.W FF /5}{JMP \emph{m16:64}}
-  {M}{Valid}{Valid}
+  {M}{Invalid}{Valid}
   {Jump far, absolute indirect, address given in \emph{m16:64}.}
 \end{x86opcodetable}
 

--- a/insn-x86-64/ret.tex
+++ b/insn-x86-64/ret.tex
@@ -9,13 +9,13 @@
   {ZO}{Valid}{Valid}
   {Near return.}
   \xopcode{CB}{RET}
-  {ZO}{Valid}{Valid}
+  {ZO}{Invalid}{Valid}
   {Far return.}
   \xopcode{C2 \emph{iw}}{RET \emph{imm16}}
   {I}{Valid}{Valid}
   {Near return and pop \emph{imm16} bytes from stack.}
   \xopcode{CA \emph{iw}}{RET \emph{imm16}}
-  {I}{Valid}{Valid}
+  {I}{Invalid}{Valid}
   {Far return and pop \emph{imm16} bytes from stack.}
 \end{x86opcodetable}
 


### PR DESCRIPTION
They are not needed to switch into 64-bit mode from capability mode and invalidating them removes the need to handle the awkward case of a far jump to a 32-bit segment from capability mode.

Note that IRET for exception return can still do a type of far branch.