### PR TITLE
Fix most undefined references

### DIFF
--- a/app-experimental.tex
+++ b/app-experimental.tex
@@ -1924,7 +1924,7 @@ Because 64-bit capabilities operate only within a 4 GiB window of the
 address space, when fetching a 64-bit capability from memory, we fill in the
 implied upper 32 bits of the full 64-bit address from the \emph{cursor} of
 the \emph{capability authorizing the fetch}.  This straightforward operation
-is provided by the \insnref{CLShC} instruction.
+is provided by the \insnnoref{CLShC} instruction.
 
 When attempting to (encode and) store a capability to a short form in memory,
 the store will fail%
@@ -1945,7 +1945,7 @@ access beyond the limits of the 4-GiB-aligned region had been shed.  Because
 short capabilities are never used directly, there is some flexibility in
 enforcement here.}
 %
-All of this is provided by the \insnref{CSShC} instruction.
+All of this is provided by the \insnnoref{CSShC} instruction.
 
 A consequence of this design is that short capabilities (transitively
 reached through short capabilities) are always interpreted within the 4 GiB

--- a/app-experimental.tex
+++ b/app-experimental.tex
@@ -25,6 +25,7 @@ experimental feature.
 \section{Additional Architectural Assistance For Revocation} % <<<
 
 \subsection{CClearTags} % <<<
+\insnriscvlabel{ccleartags} % silence undefined hyperref warning until this instruction is defined.
 
 Typically, allocators allow for the return of ``uninitialized'' memory
 (e.g., \texttt{malloc} vs.\@ \texttt{calloc}).  In the context of temporal
@@ -61,6 +62,7 @@ cache already.}
 % >>>
 \subsection{Non-Temporal (Streaming) CLC} % <<<
 \label{app:exp:clcnt}
+\insnriscvlabel{clcnt} % silence undefined hyperref warning until this instruction is defined.
 
 During revocation, whenever a capability is identified via
 \insnref{CLoadTags}, it is fetched from memory for analysis.  A large

--- a/app-experimental.tex
+++ b/app-experimental.tex
@@ -1353,7 +1353,7 @@ instructions on call rather than the one \insnref{CJALR}:
 
 	\item two to move the stack pointer
 		(\insnref{CRepresentableAlignmentMask},
-		\insnref{CAndAddr}),
+		\insnnoref{CAndAddr}),
 
 	\item four to bound the stack pointer (\insnref{CGetOffset},
 		\insnref{CSetOffset} (to zero), \insnref{CSetBounds},
@@ -1376,7 +1376,7 @@ some plausible examples include:
   \clength$) of a capability to the cursor and left the base alone could
   replace the four instruction sequence bounding the stack pointer.
 %
-  \item \insnref{CRepresentableAlignmentMask} and \insnref{CAndAddr}
+  \item \insnref{CRepresentableAlignmentMask} and \insnnoref{CAndAddr}
   could be fused into a dedicated instruction for aligning the capability's
   offset appropriately.
 %

--- a/app-experimental.tex
+++ b/app-experimental.tex
@@ -1686,8 +1686,8 @@ loaded into registers unless PCC has \cappermASR.%
 the type tag on the target memory.  This does not seem to be an especially
 high burden.  In fact, even the \cappermASR caveat can
 be removed if an alternative mechanism for tag reconstruction is made
-available to the kernel; for example, capability reconstruction as per
-\cref{section:capability-reconstruction} could gain the ability to
+available to the kernel; for example, capability reconstruction
+could gain the ability to
 reconstruct tags given the sealing authority.}
 %
 In addition to creating a sealed reference capability, sealing an object

--- a/app-versions-7-0-alpha4.tex
+++ b/app-versions-7-0-alpha4.tex
@@ -3,7 +3,7 @@ version distributed for review by DARPA and our collaborators:
 
 \begin{itemize}
 \item We have added new instructions \insnref{CSetAddr} (Set capability
-  address to value from register), \insnref{CAndAddr} (Mask address of
+  address to value from register), \insnnoref{CAndAddr} (Mask address of
   capability -- experimental), and \insnnoref{CGetAndAddr} (Move capability
   address to an integer register, with mask -- experimental), which optimize
   common virtual-address-related operations in language runtimes such as

--- a/chap-architecture.tex
+++ b/chap-architecture.tex
@@ -1616,8 +1616,7 @@ change: \insnref{CMove}.
 \item[Manipulate capability fields]
 These instructions modify capability-register fields, setting them to values
 moved from integer registers, subject to constraints such as monotonicity and
-representability: \insnref{CAndAddr}, \insnref{CAndPerm},
-\insnref{CClearTag},
+representability: \insnref{CAndPerm}, \insnref{CClearTag},
 \insnref{CIncOffset}, \insnref{CIncOffsetImm},
 \insnref{CSetAddr}, \insnref{CSetBounds},
 \insnref{CSetBoundsExact}, \insnref{CSetBoundsImm},

--- a/chap-model.tex
+++ b/chap-model.tex
@@ -1830,6 +1830,9 @@ Possible bounds on speculative execution grounded in CHERI features include:
 \item Limiting speculation across protection-domain boundary transitions.
 \end{itemize}
 
+\insnriscvlabel{cgetcid} % silence undefined hyperref warning until this instruction is defined.
+\insnriscvlabel{csetcid} % silence undefined hyperref warning until this instruction is defined.
+
 In addition, we have extended CHERI with new instructions to get and set a
 software-defined \textit{compartment ID} (CID).
 Unlike with conventional MMU-based virtual address spaces that have specific


### PR DESCRIPTION
Significantly reduces the number of warnings produced by the build - we are down to the following after this PR:

```
LaTeX Warning: Text page 31 contains only floats.
LaTeX Warning: `!h' float specifier changed to `!ht'.
LaTeX Warning: `!h' float specifier changed to `!ht'.
LaTeX Warning: Hyper reference `sailRISCVzMAX' on page 178 undefined on input l
LaTeX Warning: Hyper reference `sailRISCVzEzyFetchzyAddrzyAlign' on page 207 un
LaTeX Warning: Hyper reference `sailRISCVzEzyFetchzyAddrzyAlign' on page 209 un
LaTeX Warning: Hyper reference `sailRISCVzEzyFetchzyAddrzyAlign' on page 210 un
LaTeX Warning: Hyper reference `sailRISCVzcapszyperzycachezyline' on page 214 u
LaTeX Warning: Hyper reference `sailRISCVzEzyLoadzyAddrzyAlign' on page 214 und
LaTeX Warning: Hyper reference `sailRISCVztranslateAddr' on page 214 undefined 
LaTeX Warning: Hyper reference `sailRISCVzRead' on page 214 undefined on input 
LaTeX Warning: Hyper reference `sailRISCVzTRzyFailure' on page 214 undefined on
LaTeX Warning: Hyper reference `sailRISCVzEzyExtension' on page 214 undefined o
LaTeX Warning: Hyper reference `sailRISCVzinternalzyerror' on page 214 undefine
LaTeX Warning: Hyper reference `sailRISCVzTRzyFailure' on page 215 undefined on
LaTeX Warning: Hyper reference `sailRISCVzTRzyAddress' on page 215 undefined on
LaTeX Warning: Hyper reference `sailRISCVzEzyExtension' on page 215 undefined o
LaTeX Warning: Hyper reference `sailRISCVzMemoryOpResult' on page 215 undefined
LaTeX Warning: Hyper reference `sailRISCVzMemValue' on page 215 undefined on in
LaTeX Warning: Hyper reference `sailRISCVzMemException' on page 215 undefined o
LaTeX Warning: Hyper reference `sailRISCVzMemValue' on page 215 undefined on in
LaTeX Warning: Hyper reference `sailRISCVzmemzyreadzycap' on page 215 undefined
LaTeX Warning: Hyper reference `sailRISCVzMemException' on page 215 undefined o
LaTeX Warning: Hyper reference `sailRISCVzMemException' on page 215 undefined o
LaTeX Warning: Hyper reference `sailRISCVzMemValue' on page 215 undefined on in
LaTeX Warning: Hyper reference `sailRISCVzMemValue' on page 215 undefined on in
LaTeX Warning: Hyper reference `sailRISCVzMemException' on page 215 undefined o
LaTeX Warning: Hyper reference `sailRISCVzMemValue' on page 215 undefined on in
LaTeX Warning: Hyper reference `sailRISCVzcapszyperzycachezyline' on page 215 u
LaTeX Warning: Hyper reference `sailRISCVzexecute' on page 241 undefined on inp
LaTeX Warning: Hyper reference `sailRISCVzexecute' on page 242 undefined on inp
LaTeX Warning: Hyper reference `sailRISCVzRISCVzyJALR' on page 242 undefined on
LaTeX Font Warning: Font shape `T1/ptm/m/scit' undefined
LaTeX Font Warning: Font shape `T1/ptm/m/scit' undefined
LaTeX Font Warning: Font shape `T1/ptm/m/scit' undefined
LaTeX Font Warning: Font shape `T1/ptm/m/scit' undefined
LaTeX Font Warning: Font shape `T1/ptm/m/scit' undefined
LaTeX Warning: `h' float specifier changed to `ht'.
LaTeX Warning: There were undefined references.
```