### PR TITLE
x86: Don't set ZF for various GC* instructions.

### DIFF
--- a/insn-x86-64/gcbase.tex
+++ b/insn-x86-64/gcbase.tex
@@ -21,5 +21,4 @@ operand.  The source operand can be a register or memory location.
 
 \subsubsection*{Flags Affected}
 
-ZF is set to 1 if the result is zero.  The CF, PF, AF, SF, and OF
-flags are undefined.
+None

--- a/insn-x86-64/gchi.tex
+++ b/insn-x86-64/gchi.tex
@@ -21,5 +21,4 @@ operand.  The source operand can be a register or memory location.
 
 \subsubsection*{Flags Affected}
 
-ZF is set to 1 if the result is zero.  The CF, PF, AF, SF, and OF
-flags are undefined.
+None

--- a/insn-x86-64/gclen.tex
+++ b/insn-x86-64/gclen.tex
@@ -22,5 +22,4 @@ location.
 
 \subsubsection*{Flags Affected}
 
-ZF is set to 1 if the result is zero.  The CF, PF, AF, SF, and OF
-flags are undefined.
+None

--- a/insn-x86-64/gcoff.tex
+++ b/insn-x86-64/gcoff.tex
@@ -22,5 +22,4 @@ location.
 
 \subsubsection*{Flags Affected}
 
-ZF is set to 1 if the result is zero.  The CF, PF, AF, SF, and OF
-flags are undefined.
+None

--- a/insn-x86-64/gcperm.tex
+++ b/insn-x86-64/gcperm.tex
@@ -22,5 +22,4 @@ be a register or memory location.
 
 \subsubsection*{Flags Affected}
 
-ZF is set to 1 if the result is zero.  The CF, PF, AF, SF, and OF
-flags are undefined.
+None


### PR DESCRIPTION
There are probably not any hot paths that would need to optimize checking the result against zero.