### PR TITLE
x86: Deprecate most segment prefixes entirely in capability mode.

### DIFF
--- a/chap-cheri-x86-64.tex
+++ b/chap-cheri-x86-64.tex
@@ -274,6 +274,7 @@ longer be valid:
   \item \insnnoref{LSL}
   \item Direct memory-offset \insnnoref{MOV}
   \item Far branches (\insnnoref{CALL}, \insnnoref{JMP}, and \insnnoref{RET})
+  \item Segment Prefixes for \CS{}, \DS{}, \ES{}, and \SSreg{}
 \end{itemize}
 
 \subsection{Using Capabilities with Memory Address Operands}
@@ -911,7 +912,7 @@ aligned.  The \RIP{} and \RSP{} fields in the exception frame would be
 replaced with the full \CIP{} and \CSP{} capabilities.  Other fields
 in this frame would be padded to 16 bytes.  To minimize padding, it
 may be desirable to pack multiple smaller registers into a single
-16-byte slot; for example, \SS{}, \CS{}, and \RFLAGS{} could be stored
+16-byte slot; for example, \SSreg{}, \CS{}, and \RFLAGS{} could be stored
 in a single slot.  However, this would result in a frame layout
 inconsistent with far calls.  \insnnoref{IRETC} would be used in
 interrupt service routines to unwind this frame.

--- a/chap-isaref-x86-64.tex
+++ b/chap-isaref-x86-64.tex
@@ -253,6 +253,14 @@ or 64).
   \textbf{Opcode} & \textbf{Instruction} &
   \textbf{Description}\\
   \hline
+  26 & SEG=ES & ES segment prefix.\\
+  \hline
+  2E & SEG=CS & CS segment prefix.\\
+  \hline
+  36 & SEG=SS & SS segment prefix.\\
+  \hline
+  3E & SEG=DS & DS segment prefix.\\
+  \hline
   A0 & MOV AL,\emph{moffs8} & Move byte at (\emph{offset}) to AL.\\
   \hline
   A1 & MOV [ER]AX,\emph{moffsxx} & Move value at (\emph{offset}) to [ER]AX.\\

--- a/preamble.tex
+++ b/preamble.tex
@@ -276,9 +276,12 @@
 
 \newcommand{\AL}{{\bf AL}}
 \newcommand{\AX}{{\bf AX}}
+\newcommand{\DS}{{\bf DS}}
 \newcommand{\ES}{{\bf ES}}
 \newcommand{\FS}{{\bf FS}}
 \newcommand{\GS}{{\bf GS}}
+% \SS is an existing LaTeX command
+\newcommand{\SSreg}{{\bf SS}}
 \newcommand{\EAX}{{\bf EAX}}
 \newcommand{\CAX}{{\bf CAX}}
 \newcommand{\CBP}{{\bf CBP}}


### PR DESCRIPTION
Prefixes for CS, DS, ES, and SS are already nops in 64-bit mode.  They are already treated as invalid for capability-aware addressing in both 64-bit mode and capability mode.  This commit extends that to integer addressing in capability mode.