### PR TITLE
RISC-V: Claim to extend priv spec 1.11 instead of 1.10

### DIFF
--- a/app-experimental.tex
+++ b/app-experimental.tex
@@ -2228,7 +2228,7 @@ against a table of (region, permissions) pairs is performed, and the request
 is authorized only if the table contains a region containing the requested
 address and the request is of a type permitted by that region.  For details,
 see the RISC-V Privileged Architecture specification~\cite[\S
-3.6]{RISCV:Privileged:1.10}.
+3.6]{RISCV:Privileged:1.11}.
 
 The control interface to the PMP is, as might be imagined, based on
 integers: coarsely speaking, machine-mode code is able to write arbitrary

--- a/chap-cheri-riscv.tex
+++ b/chap-cheri-riscv.tex
@@ -37,11 +37,6 @@ Various drafts and standardized extensions add other more contemporary
 features such as hypervisor support.  There is also ongoing work to define
 broader platform behaviors beyond the architecture, including platform
 self-description and peripheral-device enumeration.
-At the time of writing, the RISC-V userspace ISA has been standardized
-(v2.2)~\cite{RISCV:User:2.2}, but the privileged ISA remains under
-development (v1.10)~\cite{RISCV:Privileged:1.10}\footnote{As v1.11 of the
-privileged specification remains a work-in-progress, we define CHERI-RISC-V
-relative to v1.10.}. \mmnote{1.11 is ratified now, so we should rewrite this chapter with v1.11 changes.}
 
 \section{CHERI-RISC-V Approach}
 
@@ -263,6 +258,10 @@ A CHERI-RISC-V processor has the X bit of the \texttt{misa} register
 hardwired to 1 on boot to indicate the presence of a non-standard
 extension.  Information tying this set X bit to the Xcheri extension
 would be communicated to system software in a platform-specific manner.
+
+CHERI-RISC-V is currently defined as a non-standard extension to
+version 2.2 of the RISC-V userspace ISA~\cite{RISCV:User:2.2} and
+version 1.11 of the RISC-V privileged ISA~\cite{RISCV:Privileged:1.11}.
 
 \subsection{Tagged Capabilities and Memory}
 

--- a/cheri.bib
+++ b/cheri.bib
@@ -15834,13 +15834,13 @@ month=sep,}
     URL = {https://content.riscv.org/wp-content/uploads/2017/05/riscv-spec-v2.2.pdf}
 }
 
-@Book{RISCV:Privileged:1.10,
+@Book{RISCV:Privileged:1.11,
     Editor = {Waterman, Andrew and Asanovi\'c, Krste},
-    Title = {{The RISC-V Instruction Set Manual, Volume II: Privileged Architecture, Version 1.10}},
+    Title = {{The RISC-V Instruction Set Manual, Volume II: Privileged Architecture, Document Version 20190608-Priv-MSU-Ratified}},
     Institution = {RISC-V Foundation},
-    Year = {2017},
-    Month = may,
-    URL = {https://content.riscv.org/wp-content/uploads/2017/05/riscv-privileged-v1.10.pdf}
+    Year = {2019},
+    Month = jun,
+    URL = {https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMFDQC-and-Priv-v1.11/riscv-privileged-20190608.pdf}
 }
 
 @incollection{watson2017:cheri-deployability,


### PR DESCRIPTION
While here, move the discussion of spec versions down to the section on CHERI as a RISC-V non-standard extension.