### PR TITLE
Restore the funding acks to footnotesize

### DIFF
--- a/cheri-architecture.tex
+++ b/cheri-architecture.tex
@@ -59,11 +59,11 @@
 \ifdefined\trformat
 \else
 \begin{minipage}[h]{\textwidth}
-  %\vspace{-.2cm}
+  \vspace{-0.5cm}
   \maketitle
 
   %\vspace{-0.2cm}
-  {\scriptsize
+  {\footnotesize
     Approved for public release; distribution is unlimited.
     Sponsored by the Defense Advanced Research Projects Agency (DARPA) and the
     Air Force Research Laboratory (AFRL), under contract FA8750-10-C-0237


### PR DESCRIPTION
Use a bit of negative vspace to pull the title block up instead of shrinking the text.